### PR TITLE
fix compilation errors and warnings

### DIFF
--- a/include/misc.h
+++ b/include/misc.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <array>
 #include <cmath>
+#include <climits>
 #include <bitset>
 #include <iostream>
 

--- a/src/atomtree.cpp
+++ b/src/atomtree.cpp
@@ -17,7 +17,7 @@ void findAdjacentRecursive(std::vector<Atom*>&, const Atom&, const double& shell
 
 // CONSTRUCTOR
 
-AtomNode::AtomNode(int atom_id, AtomNode* left_node, AtomNode* right_node) 
+AtomNode::AtomNode(int atom_id, AtomNode* left_node, AtomNode* right_node)
     : _atom_id(atom_id), left_child(left_node), right_child(right_node) {}
 
 // ACCESS
@@ -46,8 +46,8 @@ int AtomNode::getAtomId() const {
 // for testing
 void AtomNode::print(){
   std::cout << getAtom().symbol << "("
-    << getAtom().getCoordinate(0) << "," 
-    << getAtom().getCoordinate(1) << "," 
+    << getAtom().getCoordinate(0) << ","
+    << getAtom().getCoordinate(1) << ","
     << getAtom().getCoordinate(2) << ")";
 
   std::cout << "(-";
@@ -108,14 +108,14 @@ AtomNode* AtomTree::buildTree(
     return new AtomNode(
 //        AtomNode::getAtomList()[median],
         median,
-        buildTree(vec_first, median, (dim+1)%3), 
-        buildTree(median+1, vec_end, (dim+1)%3)); 
+        buildTree(vec_first, median, (dim+1)%3),
+        buildTree(median+1, vec_end, (dim+1)%3));
   }
 }
 
 double findMaxRad(std::vector<Atom>& list_of_atoms){
   double max_rad = 0;
-  for (int atom = 0; atom < list_of_atoms.size(); atom++){
+  for (size_t atom = 0; atom < list_of_atoms.size(); atom++){
     if (list_of_atoms[atom].getRad() > max_rad){
       max_rad = list_of_atoms[atom].getRad();
     }
@@ -123,15 +123,15 @@ double findMaxRad(std::vector<Atom>& list_of_atoms){
   return max_rad;
 }
 
-    
+
 void AtomTree::quicksort(std::vector<Atom>& list_of_atoms, const int& vec_first, const int& vec_end, const char& dim){
-  
+
   if(vec_first >= vec_end-1){
     return;
   }
-    
+
   double pivot = list_of_atoms[vec_end-1].getCoordinate(dim);
-  
+
   int cntr = vec_first;
 
   for(int i = vec_first; i < vec_end; i++){
@@ -185,23 +185,23 @@ std::vector<Atom*> AtomTree::findAdjacent(const Atom& at, const double& shell_to
   double min_distance = at.rad + _max_rad + shell_to_shell_dist;
 
   findAdjacentRecursive(list_of_adjacent, at, shell_to_shell_dist, min_distance, _root, dim);
-  
+
   return list_of_adjacent;
 }
 
 // changes to AtomNode and AtomTree neccessitate a reevaluation of this function
 void findAdjacentRecursive(
-    std::vector<Atom*>& list_of_adjacent, 
+    std::vector<Atom*>& list_of_adjacent,
     const Atom& atom,
     const double& shell_to_shell_dist,
     const double& min_distance,
-    const AtomNode* node, 
+    const AtomNode* node,
     int dim){
-  
+
   if (node == NULL) {return;}
   Atom* test_atom = &node->getAtom(); // for easier access
   double dist1D = distance(test_atom->getPos(), atom.getPos(), dim);
-  
+
   if (abs(dist1D) > min_distance){ // if atom is very far from test atom
     findAdjacentRecursive(
         list_of_adjacent,

--- a/src/base_guicontrol.cpp
+++ b/src/base_guicontrol.cpp
@@ -72,7 +72,7 @@ void MainFrame::displayAtomList(std::vector<std::tuple<std::string, int, double>
     atomListGrid->DeleteRows(0, atomListGrid->GetNumberRows());
   }
 
-  for (int row = 0; row < symbol_number_radius.size(); row++) {
+  for (size_t row = 0; row < symbol_number_radius.size(); row++) {
     atomListGrid->AppendRows(1, true);
     // column 1 (symbol of atom)
     atomListGrid->SetCellValue(row, 1, std::get<0>(symbol_number_radius[row]));

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -3,7 +3,7 @@
 std::string fileExtension(const std::string& path){
   // will cause an issue, if there is a dot in the middle of the file AND no file extension
   std::string after_dot = "";
-  int dot_pos = path.find_last_of(".");
+  size_t dot_pos = path.find_last_of(".");
   if (dot_pos != std::string::npos){
     return path.substr(dot_pos+1);
   }

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -48,7 +48,7 @@ void Model::setAtomListForCalculation(const std::vector<std::string>& included_e
     std::vector<std::tuple<std::string,double,double,double>>& atom_coordinates){
   atoms.clear();
 
-  for(int i = 0; i < atom_coordinates.size(); i++){
+  for(size_t i = 0; i < atom_coordinates.size(); i++){
     if(isIncluded(std::get<0>(atom_coordinates[i]), included_elements)){
       Atom at = Atom(std::get<1>(atom_coordinates[i]),
                      std::get<2>(atom_coordinates[i]),
@@ -87,9 +87,9 @@ CalcResultBundle Model::calcVolume(){
   _cell.placeAtomsInGrid(atomtree, _r_probe1); // assign each voxel in grid a type, defined by the atom positions
   auto end = std::chrono::steady_clock::now();
   data.type_assignment_elapsed_seconds = std::chrono::duration<double>(end-start).count();
-  
+
   //_cell.printGrid(); // for testing
-  
+
   start = std::chrono::steady_clock::now();
   data.volumes = _cell.getVolume();
   end = std::chrono::steady_clock::now();
@@ -265,7 +265,7 @@ bool Model::symmetrizeUnitCell(){
       ABC_coord.emplace_back(std::get<0>(processed_atom_coordinates[i]), sym_abc[0], sym_abc[1], sym_abc[2]);
     }
   }
-  for (int i = 0; i < ABC_coord.size(); i++){ // converts new list of atoms after applying symmetry to cartesian coordinates
+  for (size_t i = 0; i < ABC_coord.size(); i++){ // converts new list of atoms after applying symmetry to cartesian coordinates
     double atom_xyz[3] = {0,0,0};
     double atom_abc[3] = {std::get<1>(ABC_coord[i]), std::get<2>(ABC_coord[i]), std::get<3>(ABC_coord[i])};
     for (int j = 0; j < 3; j++){
@@ -280,7 +280,7 @@ bool Model::symmetrizeUnitCell(){
 
 // 3) if atoms outside the orthogonal cell, move them inside
 void Model::moveAtomsInsideCell(){
-  for(int n = 0; n < processed_atom_coordinates.size(); n ++){
+  for(size_t n = 0; n < processed_atom_coordinates.size(); n ++){
     while(std::get<3>(processed_atom_coordinates[n]) < 0){ // need to start with Z axis because the unit cell C axis can have X and Y components
       std::get<3>(processed_atom_coordinates[n]) += cart_matrix[2][2];
       std::get<2>(processed_atom_coordinates[n]) += cart_matrix[2][1];
@@ -310,8 +310,8 @@ void Model::moveAtomsInsideCell(){
 
 // 4) remove duplicate atoms (allow 0.01-0.05 A error)
 void Model::removeDuplicateAtoms(){
-  for(int i = 0; i < processed_atom_coordinates.size(); i++){
-    for(int j = i+1; j < processed_atom_coordinates.size(); j++){
+  for(size_t i = 0; i < processed_atom_coordinates.size(); i++){
+    for(size_t j = i+1; j < processed_atom_coordinates.size(); j++){
       if(std::get<0>(processed_atom_coordinates[i]) == std::get<0>(processed_atom_coordinates[j]) &&
          std::abs(std::get<1>(processed_atom_coordinates[i])-std::get<1>(processed_atom_coordinates[j])) < 0.05 &&
          std::abs(std::get<2>(processed_atom_coordinates[i])-std::get<2>(processed_atom_coordinates[j])) < 0.05 &&
@@ -376,7 +376,7 @@ void Model::generateSupercell(double radius_limit){
 
 // 6) create atom map based on cell limits + radius= 2*(max_atom_rad+probe1+probe2+gridstep)
 void Model::generateUsefulAtomMapFromSupercell(double radius_limit){
-  for(int i = 0; i < processed_atom_coordinates.size(); i++){
+  for(size_t i = 0; i < processed_atom_coordinates.size(); i++){
     if(std::get<1>(processed_atom_coordinates[i]) < -radius_limit ||
        std::get<2>(processed_atom_coordinates[i]) < -radius_limit ||
        std::get<3>(processed_atom_coordinates[i]) < -radius_limit ||

--- a/src/model_filereading.cpp
+++ b/src/model_filereading.cpp
@@ -38,11 +38,11 @@ bool Model::readRadiiAndAtomNumFromFile(std::string& radius_path){
 // generates two two maps for assigning a radius/ atomic number respectively, to a element symbol
 // sets the maps to members of the model class
 bool Model::readRadiusFileSetMaps(std::string& radius_path){
-  
+
   RadiusFileBundle data = importDataFromRadiusFile(radius_path);
 
   if (data.rad_map.size() == 0) {return false;}
-  
+
   setRadiusMap(data.rad_map);
   elem_Z = data.atomic_num_map;
   return true;
@@ -63,7 +63,7 @@ bool Model::readAtomsFromFile(const std::string& filepath, bool include_hetatm){
   // this function should ideally end in a set function, and the other functions should have return
   // values -JM
   clearAtomData();
-  
+
   try{
     readAtomFile(filepath, include_hetatm);
   } catch(const ExceptIllegalFileExtension& e) {
@@ -106,7 +106,7 @@ void Model::readFileXYZ(const std::string& filepath){
   while(getline(inp_file,line)){
     std::vector<std::string> substrings = splitLine(line);
     // substrings[0]: Element Symbol
-    // substrings[1,2,3]: Coordinates 
+    // substrings[1,2,3]: Coordinates
     // create new atom and add to storage vector if line format corresponds to Element_Symbol x y z
     if (isAtomLine(substrings)) {
 
@@ -177,7 +177,7 @@ std::vector<std::string> Model::listElementsInStructure(){
 }
 
 bool Model::getSymmetryElements(std::string group, std::vector<int> &sym_matrix_XYZ, std::vector<double> &sym_matrix_fraction){
-  for (int i = 0; i<group.size(); i++) { // convert space group to upper case chars to compare with the list
+  for (size_t i = 0; i<group.size(); i++) { // convert space group to upper case chars to compare with the list
     group[i] = toupper(group[i]);
   }
   group = "'" + group + "'";
@@ -278,7 +278,7 @@ bool isAtomLine(const std::vector<std::string>& substrings) {
 // reads a string and converts it to valid atom symbol: first character uppercase followed by lowercase characters
 std::string strToValidSymbol(std::string str){
   // iterate over all characters in string
-  for (int i = 0; i<str.size(); i++) {
+  for (size_t i = 0; i<str.size(); i++) {
 // TODO: decide whether non-alphabetic characters should be erased or not
 //    if (isalpha(str[i])){
       // only for first character in sequence, convert to uppercase
@@ -300,7 +300,7 @@ std::string strToValidSymbol(std::string str){
 
 RadiusFileBundle importDataFromRadiusFile(const std::string& radius_path){
   RadiusFileBundle data;
-  
+
   std::string line;
   std::ifstream inp_file(radius_path);
   while(getline(inp_file,line)){

--- a/src/model_outputfiles.cpp
+++ b/src/model_outputfiles.cpp
@@ -36,7 +36,7 @@ void Model::createReport(std::string input_filepath, std::vector<std::string> pa
   std::ofstream output_report(output_folder+"/MoloVol result report.txt");
   output_report << "MoloVol program: calculation results report\n\n";
   output_report << "Structure file analyzed: " << input_filepath << "\n";
-  for(int i = 0; i < parameters.size(); i++){
+  for(size_t i = 0; i < parameters.size(); i++){
     output_report << parameters[i] << "\n";
   }
   output_report.close();
@@ -49,7 +49,7 @@ void Model::createReport(std::string input_filepath, std::vector<std::string> pa
 void Model::writeXYZfile(std::vector<std::tuple<std::string, double, double, double>> &atom_coordinates, std::string output_type){
   std::ofstream output_structure(output_folder+"/structure_"+output_type+".xyz");
   output_structure << output_type << "\nStructure generated with MoloVol\n\n";
-  for(int i = 0; i < atom_coordinates.size(); i++){
+  for(size_t i = 0; i < atom_coordinates.size(); i++){
     output_structure << std::get<0>(atom_coordinates[i]) << " ";
     output_structure << std::to_string(std::get<1>(atom_coordinates[i])) << " ";
     output_structure << std::to_string(std::get<2>(atom_coordinates[i])) << " ";
@@ -63,14 +63,14 @@ void Model::writeXYZfile(std::vector<std::tuple<std::string, double, double, dou
 ////////////////////////
 
 void Model::writeSurfaceMap(std::string output_dir){
-  
+
   // assemble data
   Container3D<char> surface_map = _cell.generateTypeTensor();
   // save commonly used variable
   std::array<unsigned long int,3> n_elements = surface_map.getNumElements();
   double vxl_length = _cell.getResolution();
   // create map for assigning numbers to types
-  std::map<char,int> typeToNum = 
+  std::map<char,int> typeToNum =
     {{0b00000011, 0},
      {0b00000101, 2},
      {0b00001001, 6},

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -28,20 +28,20 @@ Space::Space(std::vector<Atom> &atoms, const double bot_lvl_vxl_dist, const int 
 // that all atoms fit the space.
 void Space::setBoundaries(const std::vector<Atom> &atoms, const double add_space){
   double max_radius = 0;
-  for(int at = 0; at < atoms.size(); at++){
+  for(size_t at = 0; at < atoms.size(); at++){
     std::array<double,3> atom_pos = atoms[at].getPos();
-  
+
     // if we are at the first atom, then the atom position is min/max by default
     if(at == 0){
       cart_min = atom_pos;
       cart_max = atom_pos;
       max_radius = atoms[at].rad;
     }
-    
+
     // after the first atom, begin comparing the atom positions to min/max and save if exceeds previously saved values
     else{
-      for(int dim = 0; dim < 3; dim++){ 
-        if(atom_pos[dim] > cart_max[dim]){ 
+      for(int dim = 0; dim < 3; dim++){
+        if(atom_pos[dim] > cart_max[dim]){
           cart_max[dim] = atom_pos[dim];
         }
         if(atom_pos[dim] < cart_min[dim]){
@@ -54,9 +54,9 @@ void Space::setBoundaries(const std::vector<Atom> &atoms, const double add_space
     }
   }
   // expand boundaries by a little more than the largest atom found
-  for(int dim = 0; dim < 3; dim++){ 
+  for(int dim = 0; dim < 3; dim++){
     cart_min[dim] -= (add_space + max_radius);
-    cart_max[dim] += (add_space + max_radius);    
+    cart_max[dim] += (add_space + max_radius);
   }
   return;
 }
@@ -70,8 +70,8 @@ void Space::initGrid(){
   }
   for (int lvl = 0; lvl <= max_depth; ++lvl){
     _grid.push_back(Container3D<Voxel>
-        (n_gridsteps[0]*pow(2,max_depth-lvl), 
-         n_gridsteps[1]*pow(2,max_depth-lvl), 
+        (n_gridsteps[0]*pow(2,max_depth-lvl),
+         n_gridsteps[1]*pow(2,max_depth-lvl),
          n_gridsteps[2]*pow(2,max_depth-lvl)));
   }
   return;
@@ -87,7 +87,7 @@ void Space::placeAtomsInGrid(const AtomTree& atomtree, const double& r_probe){
   Voxel::prepareTypeAssignment(this, atomtree, grid_size, r_probe, max_depth);
 
   assignAtomVsCore();
-  
+
   updateGrid();
 
   assignShellVsVoid();
@@ -98,9 +98,9 @@ void Space::placeAtomsInGrid(const AtomTree& atomtree, const double& r_probe){
 // updates the grids
 // using pointers in the grid could make this step avoidable
 void Space::updateGrid(){
-  for (int x = 0; x < n_gridsteps[0]; ++x){
-    for (int y = 0; y < n_gridsteps[1]; ++y){
-      for (int z = 0; z < n_gridsteps[2]; ++z){
+  for (unsigned int x = 0; x < n_gridsteps[0]; ++x){
+    for (unsigned int y = 0; y < n_gridsteps[1]; ++y){
+      for (unsigned int z = 0; z < n_gridsteps[2]; ++z){
         Voxel top_lvl_vxl = getTopVxl(x,y,z);
         fillGrid(top_lvl_vxl, x, y, z, max_depth);
       }
@@ -125,7 +125,7 @@ void Space::fillGrid(Voxel& vxl, int x, int y, int z, unsigned lvl){
     }
   }
 }
-  
+
 void Space::assignAtomVsCore(){
   // calculate position of first voxel
   const std::array<double,3> vxl_origin = getOrigin();
@@ -160,23 +160,23 @@ void Space::assignShellVsVoid(){
 
 std::map<char,double> Space::getVolume(){
   std::vector<char> types_to_tally{0b00000011,0b00000101};
-  
+
   std::vector<unsigned int> tally;
-  for (char i = 0; i < types_to_tally.size(); i++){
+  for (size_t i = 0; i < types_to_tally.size(); i++){
     tally.push_back(0);
   }
 
   for(unsigned int i = 0; i < n_gridsteps[0] * n_gridsteps[1] * n_gridsteps[2]; i++){ // loop through all top level voxels
     // tally bottom level voxels
-    
-    for (char j = 0; j < types_to_tally.size(); j++){
+
+    for (size_t j = 0; j < types_to_tally.size(); j++){
       tally[j] += getTopVxl(i).tallyVoxelsOfType(types_to_tally[j],max_depth);
     }
   }
   double unit_volume = pow(grid_size,3);
 
   std::map<char,double> volumes;
-  for (char i = 0; i < types_to_tally.size(); i++){
+  for (size_t i = 0; i < types_to_tally.size(); i++){
     volumes[types_to_tally[i]] = tally[i] * unit_volume;
   }
 /*
@@ -193,7 +193,7 @@ std::map<char,double> Space::getVolume(){
 Container3D<char> Space::generateTypeTensor(){
   // reserve memory
   Container3D<char> type_tensor = Container3D<char>(gridstepsOnLvl(0));
- 
+
   std::array<unsigned long int,3> block_start = {0,0,0};
   int n_bot_lvl_vxl = pow(2,max_depth);
   for (unsigned int i = 0; i < n_gridsteps[0]; i++){
@@ -205,8 +205,8 @@ Container3D<char> Space::generateTypeTensor(){
         getTopVxl(i,j,k).fillTypeTensor(type_tensor, block_start, max_depth);
       }
     }
-  } 
-  return type_tensor; 
+  }
+  return type_tensor;
 }
 
 //////////////////////
@@ -258,19 +258,19 @@ Voxel& Space::getVxlFromGrid(const std::array<int,3> arr, unsigned lvl){
 }
 
 Voxel& Space::getTopVxl(const unsigned int i){
-  return getVxlFromGrid(i, max_depth); 
+  return getVxlFromGrid(i, max_depth);
 }
 
 Voxel& Space::getTopVxl(const unsigned int x, const unsigned int y, const unsigned int z){
-  return getVxlFromGrid(x, y, z, max_depth); 
+  return getVxlFromGrid(x, y, z, max_depth);
 }
 
 Voxel& Space::getTopVxl(const std::array<unsigned int,3> arr){
-  return getVxlFromGrid(arr, max_depth); 
+  return getVxlFromGrid(arr, max_depth);
 }
 
 Voxel& Space::getTopVxl(const std::array<int,3> arr){
-  return getVxlFromGrid(arr, max_depth); 
+  return getVxlFromGrid(arr, max_depth);
 }
 
 /////////////////
@@ -293,7 +293,7 @@ Voxel& Space::getVxl(const std::array<int,3>& arr, int lvl){
 Voxel& Space::getVxl(int x, int y, int z, int lvl){
   return getVxl({x,y,z}, lvl);
 }
-      
+
 // check whether coord is inside grid bounds
 bool Space::coordInBounds(const std::array<int,3>& coord, const unsigned lvl){
   for (char i = 0; i < 3; i++){
@@ -305,7 +305,7 @@ bool Space::coordInBounds(const std::array<int,3>& coord, const unsigned lvl){
 std::array<unsigned int,3> Space::getGridsteps(){
   return n_gridsteps;
 }
-    
+
 unsigned long int Space::totalVxlOnLvl(const int lvl) const{
   unsigned long int total = 1;
   const std::array<unsigned long int,3> gridsteps = gridstepsOnLvl(lvl);
@@ -323,7 +323,7 @@ const std::array<unsigned long int,3> Space::gridstepsOnLvl(const int level) con
   }
   return n_voxels;
 }
- 
+
 ////////////////
 // PRINT GRID //
 ////////////////
@@ -337,21 +337,21 @@ std::array<unsigned int,3> makeIndices(std::array<unsigned int,3> indices, int d
 
 // displays voxel grid types as matrix in the terminal. useful for debugging
 void Space::printGrid(){
-  
+
   int depth = 0;
   std::array<unsigned int,3> indices = makeIndices(n_gridsteps, depth);
 
-  int x_min = 0;
-  int y_min = 0;
-  
-  int x_max = ((indices[0] >= 50)? 50: indices[0]);
-  int y_max = ((indices[1] >= 25)? 25: indices[1]);
+  unsigned int x_min = 0;
+  unsigned int y_min = 0;
+
+  unsigned int x_max = ((indices[0] >= 50)? 50: indices[0]);
+  unsigned int y_max = ((indices[1] >= 25)? 25: indices[1]);
 
   unsigned int z = 0;
   std::cout << "Enter 'q' to quit; 'w', 'a', 's', 'd' for directional input; 'c' to continue in z direction; 'r' to go back in z direction. Enter '+' or '-' to change the octree depth." << std::endl;
   char usr_inp = '\0';
   while (usr_inp != 'q'){
-  
+
     // if depth is changed, reset view
     if (usr_inp == '+' || usr_inp == '-'){
       if (usr_inp == '+' && depth < max_depth){depth++;}
@@ -369,12 +369,12 @@ void Space::printGrid(){
     else if (usr_inp == 'd'){x_min++; x_max++;}
     else if (usr_inp == 's'){y_min++; y_max++;}
     else if (usr_inp == 'w'){y_min--; y_max--;}
-    
+
     if (x_min < 0){x_min++; x_max++;}
     if (y_min < 0){y_min++; y_max++;}
     if (x_max > indices[0]){x_min--; x_max--;}
     if (y_max > indices[1]){y_min--; y_max--;}
-    
+
     // z coordinate
     if (usr_inp == 'r'){
       if (z==0){
@@ -389,7 +389,7 @@ void Space::printGrid(){
         std::cout << "z position at max. " << std::endl;
       }
     }
-    
+
     // print matrix
     for(unsigned int y = y_min; y < y_max; y++){
       for(unsigned int x = x_min; x < x_max; x++){
@@ -397,12 +397,12 @@ void Space::printGrid(){
         if (!readBit(getVxl(x,y,z,max_depth-depth).getType(),0)){to_print = '?';}
         if (getVxl(x,y,z,max_depth-depth).getType() == 0b00010001){to_print = 'S';}
         if (getVxl(x,y,z,max_depth-depth).getType() == 0b00000101){to_print = 'X';}
-        
+
         std::cout << to_print << " ";
       }
       std::cout << std::endl;
     }
-    
+
     // get user input
     std::cout << std::endl;
     std::cout << "INPUT: ";


### PR DESCRIPTION
Included libraries that were necessary to compile on windows 10 with GNU GCC.
Fixed several warnings related to different signedness comparison.
Many white spaces were automatically removed by my IDE. 
There are still two unused variables (tagged with // TODO remark) and a reorder warning.