### PR TITLE
Surface area

### DIFF
--- a/include/cavity.h
+++ b/include/cavity.h
@@ -10,13 +10,16 @@ struct Cavity{
   Cavity() = default;
   Cavity(unsigned char id, double core_vol, double shell_vol, std::array<double,3> min_bound, std::array<double,3> max_bound, std::array<size_t,3> min_index, std::array<size_t,3> max_index) : 
     id(id), core_vol(core_vol), shell_vol(shell_vol), min_bound(min_bound), max_bound(max_bound), min_index(min_index), max_index(max_index){};
-  unsigned char id;
+  unsigned char id; // the number assigned to core and shell voxels belonging to this cavity
   double core_vol;
   double shell_vol;
   std::array<double,3> min_bound;
   std::array<double,3> max_bound;
   std::array<size_t,3> min_index;
   std::array<size_t,3> max_index;
+
+  double surf_core;
+  double surf_shell;
 
   double getVolume() const;
 };

--- a/include/cavity.h
+++ b/include/cavity.h
@@ -22,6 +22,8 @@ struct Cavity{
   double surf_shell;
 
   double getVolume() const;
+  double getSurfCore() const;
+  double getSurfShell() const;
 };
 
 bool compareVolume(const Cavity& a, const Cavity& b);

--- a/include/controller.h
+++ b/include/controller.h
@@ -26,6 +26,7 @@ class Ctrl{
     bool unittestProtein();
     bool unittestRadius();
     bool unittest2Probe();
+    bool unittestSurface();
 
   private:
     // consider making static pointer for model

--- a/include/model.h
+++ b/include/model.h
@@ -100,6 +100,7 @@ class Model{
 
     // controller-model communication
     CalcReportBundle generateVolumeData();
+    CalcReportBundle generateSurfaceData();
     // calls the Space constructor and creates a cell containing all atoms. Cell size is defined by atom positions
     void defineCell();
     void setAtomListForCalculation();

--- a/include/model.h
+++ b/include/model.h
@@ -20,6 +20,7 @@ struct CalcReportBundle{
   // switches
   bool inc_hetatm;
   bool analyze_unit_cell;
+  bool calc_surface_areas;
   bool probe_mode;
   // parameters for calculation
   double grid_step;
@@ -90,6 +91,7 @@ class Model{
     inline double findRadiusOfAtom(const Atom&); //TODO has not been tested
 
     // controller-model communication
+    CalcReportBundle generateData();
     CalcReportBundle generateVolumeData();
     CalcReportBundle generateSurfaceData();
     // calls the Space constructor and creates a cell containing all atoms. Cell size is defined by atom positions
@@ -99,7 +101,7 @@ class Model{
     void linkAtomsToAdjacentAtoms(const double&);
     void linkToAdjacentAtoms(const double&, Atom&);
     CalcReportBundle calcVolume();
-    bool setParameters(std::string, std::string, bool, bool, bool, double, double, double, int, bool, bool, bool, std::unordered_map<std::string, double>, std::vector<std::string>, double);
+    bool setParameters(std::string, std::string, bool, bool, bool, bool, double, double, double, int, bool, bool, bool, std::unordered_map<std::string, double>, std::vector<std::string>, double);
     CalcReportBundle getBundle(); // TODO remove if unused
     std::vector<std::tuple<std::string, int, double>> generateAtomList();
     void setRadiusMap(std::unordered_map<std::string, double> map);
@@ -135,6 +137,7 @@ class Model{
     bool optionIncludeHetatm(){return _data.inc_hetatm;}
     bool optionAnalyzeUnitCell(){return _data.analyze_unit_cell;}
     bool optionAnalyseUnitCell(){return _data.analyze_unit_cell;}
+    bool optionCalcSurfaceAreas(){return _data.calc_surface_areas;}
 };
 
 

--- a/include/model.h
+++ b/include/model.h
@@ -24,38 +24,29 @@ struct CalcReportBundle{
   // parameters for calculation
   double grid_step;
   int max_depth;
-  double r_probe1 = 0;
-  double r_probe2 = 0;
+  double r_probe1;
+  double r_probe2;
   std::vector<std::string> included_elements;
   std::string chemical_formula;
   // output options
   bool make_report;
   bool make_full_map;
   bool make_cav_maps;
-  // calculation results
+  // volumes
   std::map<char,double> volumes;
+  // surfaces
+  double surf_vdw;
+  double surf_probe_inaccessible;
+  // cavity volumes and surfaces
   std::vector<Cavity> cavities;
   double getCavVolume(const unsigned char i){return cavities[i].getVolume();}
-  std::array<double,3> getCavCentre(const unsigned char i){
-    std::array<double,3> cav_ctr;
-    for (char j = 0; j < 3; ++j){
-      cav_ctr[j] = (cavities[i].min_bound[j] + cavities[i].max_bound[j])/2;
-    }
-    return cav_ctr;
-  }
+  std::array<double,3> getCavCentre(const unsigned char);
   std::array<double,3> getCavCenter(const unsigned char i){return getCavCentre(i);}
-  std::map<char,double> surfaces;
   // time
   std::vector<double> elapsed_seconds;
   void addTime(const double t){elapsed_seconds.push_back(t);}
   double getTime(const unsigned i){return elapsed_seconds[i];}
-  double getTime(){
-    double total_seconds = 0;
-    for (const double time : elapsed_seconds){
-      total_seconds += time;
-    }
-    return total_seconds;
-  }
+  double getTime();
 };
 
 class AtomTree;

--- a/include/model.h
+++ b/include/model.h
@@ -38,11 +38,15 @@ struct CalcReportBundle{
   // surfaces
   double surf_vdw;
   double surf_probe_inaccessible;
+  double getSurfVdw(){return surf_vdw;}
+  double getSurfProbeInaccessible(){return surf_probe_inaccessible;}
   // cavity volumes and surfaces
   std::vector<Cavity> cavities;
   double getCavVolume(const unsigned char i){return cavities[i].getVolume();}
   std::array<double,3> getCavCentre(const unsigned char);
   std::array<double,3> getCavCenter(const unsigned char i){return getCavCentre(i);}
+  double getCavSurfCore(const unsigned char i) const {return cavities[i].getSurfCore();}
+  double getCavSurfShell(const unsigned char i) const {return cavities[i].getSurfShell();}
   // time
   std::vector<double> elapsed_seconds;
   void addTime(const double t){elapsed_seconds.push_back(t);}

--- a/include/space.h
+++ b/include/space.h
@@ -56,6 +56,9 @@ class Space{
                             std::map<unsigned char, std::array<unsigned,3>>&,
                             std::map<unsigned char, std::array<unsigned,3>>&);
 
+    // surface area
+    std::vector<std::vector<double>> sumSurfArea(const std::vector<std::vector<char>>&, const std::vector<bool>&);
+
   private:
     std::array <double,3> cart_min; // this is also the "origin" of the space
     std::array <double,3> cart_max;

--- a/include/space.h
+++ b/include/space.h
@@ -57,7 +57,7 @@ class Space{
                             std::map<unsigned char, std::array<unsigned,3>>&);
 
     // surface area
-    std::vector<std::vector<double>> sumSurfArea(const std::vector<std::vector<char>>&, const std::vector<bool>&);
+    std::vector<std::vector<double>> sumSurfArea(const std::vector<std::vector<char>>&, const std::vector<bool>&, const unsigned char);
 
   private:
     std::array <double,3> cart_min; // this is also the "origin" of the space

--- a/include/space.h
+++ b/include/space.h
@@ -79,4 +79,13 @@ class Space{
 
 };
 
+class SurfaceLUT {
+  private:
+    static const std::array<unsigned char,256> types_by_config;
+    static const std::array<double, 15> area_by_config;
+  public:
+    static unsigned char configToType(unsigned char config);
+    static double typeToArea(unsigned char type);
+};
+
 #endif

--- a/include/special_chars.h
+++ b/include/special_chars.h
@@ -8,6 +8,7 @@
 class Symbol{
   public:
     static std::wstring angstrom();
+    static std::wstring squared();
     static std::wstring cubed();
     static std::wstring numSubscript(int num);
     static std::wstring numSubscript(std::string num);

--- a/include/voxel.h
+++ b/include/voxel.h
@@ -37,9 +37,9 @@ class Voxel{
     Voxel& getSubvoxel(std::array<unsigned,3>, const unsigned, const char);
     Voxel& getSubvoxel(std::array<unsigned,3>, const unsigned);
     void setType(char);
-    char getType();
+    char getType() const;
     void setID(unsigned char);
-    unsigned char getID();
+    unsigned char getID() const;
 
     // bitwise operations on _type
     bool hasSubvoxel(); // state of bit 7

--- a/src/base_init.cpp
+++ b/src/base_init.cpp
@@ -45,6 +45,9 @@ bool MainApp::OnInit()
     else if (unittest_id=="2probe"){
       Ctrl::getInstance()->unittest2Probe();
     }
+    else if (unittest_id=="surface"){
+      Ctrl::getInstance()->unittestSurface();
+    }
     else {
       std::cout << "Invalid selection" << std::endl;}
     return true;

--- a/src/base_init.cpp
+++ b/src/base_init.cpp
@@ -362,7 +362,7 @@ void MainFrame::InitParametersPanel(){
   surfaceAreaCheckbox = new wxCheckBox
     (parameterPanel,
      CHECKBOX_SurfaceArea,
-     "Calculate surface areas (NOT AVAILABLE YET !)",
+     "Calculate surface areas",
      wxDefaultPosition,
      wxDefaultSize,
      0,

--- a/src/cavity.cpp
+++ b/src/cavity.cpp
@@ -1,8 +1,9 @@
 #include "cavity.h"
 
-double Cavity::getVolume() const {
-  return core_vol + shell_vol;
-}
+double Cavity::getVolume() const {return core_vol + shell_vol;}
+
+double Cavity::getSurfShell() const {return surf_shell;}
+double Cavity::getSurfCore() const {return surf_core;}
 
 bool compareVolume(const Cavity& a, const Cavity& b){
   return a.getVolume() < b.getVolume();

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -100,7 +100,12 @@ bool Ctrl::runCalculation(){
       gui->getMaxRad())){
     return false;
   }
+
   CalcReportBundle data = current_calculation->generateVolumeData();
+  // surface calculation requires running the volume calculation first, but shouldn't be inside the volume calc function
+  if (data.success){
+    data = current_calculation->generateSurfaceData();
+  }
 
   if (data.success){
     notifyUser("\nResult for ");

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -112,6 +112,10 @@ bool Ctrl::runCalculation(){
     notifyUser(Symbol::angstrom() + Symbol::cubed());
     notifyUser("\nExcluded void volume: " + std::to_string(data.volumes[0b00000101]) + " ");
     notifyUser(Symbol::angstrom() + Symbol::cubed());
+    if (data.calc_surface_areas){
+      notifyUser("\nVan der Waals surface: " + std::to_string(data.getSurfVdw()));
+      notifyUser("\nProbe inaccessible surface: " + std::to_string(data.getSurfProbeInaccessible()));
+    }
     notifyUser("\nProbe 1 core volume: " + std::to_string(data.volumes[0b00001001]) + " ");
     notifyUser(Symbol::angstrom() + Symbol::cubed());
     notifyUser("\nProbe 1 shell volume: " + std::to_string(data.volumes[0b00010001]) + " ");
@@ -127,9 +131,13 @@ bool Ctrl::runCalculation(){
       for (size_t i = 0; i < data.cavities.size(); ++i){
         notifyUser("\nCav " + std::to_string(i+1) + ": " + std::to_string(data.getCavVolume(i)) + " ");
         notifyUser(Symbol::angstrom() + Symbol::cubed());
-        notifyUser("(" + std::to_string(data.getCavCentre(i)[0]) + ", "
+        notifyUser(" (" + std::to_string(data.getCavCentre(i)[0]) + ", "
           + std::to_string(data.getCavCentre(i)[1]) + ", "
           + std::to_string(data.getCavCentre(i)[2]) + ")");
+        if (data.calc_surface_areas){
+          notifyUser("\nCore Area: " + std::to_string(data.getCavSurfCore(i)));
+          notifyUser(" Shell Area: " + std::to_string(data.getCavSurfShell(i)));
+        }
       }
     }
   }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -87,6 +87,7 @@ bool Ctrl::runCalculation(){
       gui->getOutputDir(),
       gui->getIncludeHetatm(),
       gui->getAnalyzeUnitCell(),
+      gui->getCalcSurfaceAreas(),
       gui->getProbeMode(),
       gui->getProbe1Radius(),
       gui->getProbe2Radius(),
@@ -101,11 +102,7 @@ bool Ctrl::runCalculation(){
     return false;
   }
 
-  CalcReportBundle data = current_calculation->generateVolumeData();
-  // surface calculation requires running the volume calculation first, but shouldn't be inside the volume calc function
-  if (data.success){
-    data = current_calculation->generateSurfaceData();
-  }
+  CalcReportBundle data = current_calculation->generateData();
 
   if (data.success){
     notifyUser("\nResult for ");

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -113,8 +113,10 @@ bool Ctrl::runCalculation(){
     notifyUser("\nExcluded void volume: " + std::to_string(data.volumes[0b00000101]) + " ");
     notifyUser(Symbol::angstrom() + Symbol::cubed());
     if (data.calc_surface_areas){
-      notifyUser("\nVan der Waals surface: " + std::to_string(data.getSurfVdw()));
-      notifyUser("\nProbe inaccessible surface: " + std::to_string(data.getSurfProbeInaccessible()));
+      notifyUser("\nVan der Waals surface: " + std::to_string(data.getSurfVdw()) + " ");
+      notifyUser(Symbol::angstrom() + Symbol::squared());
+      notifyUser("\nProbe inaccessible surface: " + std::to_string(data.getSurfProbeInaccessible()) + " ");
+      notifyUser(Symbol::angstrom() + Symbol::squared());
     }
     notifyUser("\nProbe 1 core volume: " + std::to_string(data.volumes[0b00001001]) + " ");
     notifyUser(Symbol::angstrom() + Symbol::cubed());
@@ -135,8 +137,10 @@ bool Ctrl::runCalculation(){
           + std::to_string(data.getCavCentre(i)[1]) + ", "
           + std::to_string(data.getCavCentre(i)[2]) + ")");
         if (data.calc_surface_areas){
-          notifyUser("\nCore Area: " + std::to_string(data.getCavSurfCore(i)));
-          notifyUser(" Shell Area: " + std::to_string(data.getCavSurfShell(i)));
+          notifyUser("\nCore Area: " + std::to_string(data.getCavSurfCore(i)) + " ");
+          notifyUser(Symbol::angstrom() + Symbol::squared());
+          notifyUser(" Shell Area: " + std::to_string(data.getCavSurfShell(i)) + " ");
+          notifyUser(Symbol::angstrom() + Symbol::squared());
         }
       }
     }

--- a/src/controller_unittest.cpp
+++ b/src/controller_unittest.cpp
@@ -211,7 +211,7 @@ bool Ctrl::unittest2Probe(){
         atom_filepath.c_str(), grid_step, max_depth, rad_probe1, rad_probe2);
     printf("vdW: %20.10f, Excluded: %20.10f\n", data.volumes[0b00000011]-28.866, data.volumes[0b00000101]-6.224);
     printf("P1 Core: %20.10f, P1 Shell: %20.10f\n", data.volumes[0b00001001]-0.202, data.volumes[0b00010001]-5.702);
-    printf("P2 Core: %20.10f, P1 Shell: %20.10f\n", data.volumes[0b00100001]-681.534, data.volumes[0b01000001]-309.664);
+    printf("P2 Core: %20.10f, P2 Shell: %20.10f\n", data.volumes[0b00100001]-681.534, data.volumes[0b01000001]-309.664);
     printf("Time elapsed: %10.5f s\n", data.getTime()-2.12);
   }
   else{
@@ -220,3 +220,56 @@ bool Ctrl::unittest2Probe(){
   return true;
 }
 
+bool Ctrl::unittestSurface(){
+  if(current_calculation == NULL){current_calculation = new Model();}
+
+  // parameters for unittest:
+  const std::string atom_filepath = "./inputfile/probetest_quadruplet.xyz";
+  const std::string radius_filepath = "./inputfile/radii.txt";
+  double rad_probe2 = 2;
+  double rad_probe1 = 0.5;
+  bool two_probe = false;
+  int max_depth = 4;
+  double grid_step = 0.1;
+
+  std::unordered_map<std::string, double> rad_map = current_calculation->importRadiusMap(radius_filepath);
+
+  CalcReportBundle data;
+  current_calculation->readAtomsFromFile(atom_filepath, false);
+  std::vector<std::string> included_elements = current_calculation->listElementsInStructure();
+
+  current_calculation->setParameters(
+      atom_filepath,
+      "./output",
+      false,
+      false,
+      two_probe,
+      rad_probe1,
+      rad_probe2,
+      grid_step,
+      max_depth,
+      false,
+      false,
+      false,
+      rad_map,
+      included_elements,
+      3);
+
+  current_calculation->generateVolumeData();
+  data = current_calculation->generateSurfaceData();
+
+  if(data.success){
+    printf("f: %40s, g: %4.2f, d: %4i, r1: %4.1f\n", atom_filepath.c_str(), grid_step, max_depth, rad_probe1);
+    printf("vdW: %20.10f, Excluded: %20.10f\n", data.volumes[0b00000011]-28.948, data.volumes[0b00000101]-1.86);
+    printf("P1 Core: %20.10f, P1 Shell: %20.10f\n", data.volumes[0b00001001]-247.748, data.volumes[0b00010001]-49.124);
+    std::vector<double> cav = {294.75,1.34,0.252,0.187,0.187,0.078,0.078};
+    for (int i = 0; i< data.cavities.size(); ++i){
+      printf("Cavity vol: %20.10f A^3\n", data.getCavVolume(i)-cav[i]);
+    }
+    printf("Time elapsed: %10.5f s\n", data.getTime()-0.83+0.74);
+  }
+  else{
+    std::cout << "Calculation failed" << std::endl;
+  }
+  return true;
+}

--- a/src/controller_unittest.cpp
+++ b/src/controller_unittest.cpp
@@ -33,6 +33,7 @@ bool Ctrl::unittestExcluded(){
         false,
         false,
         false,
+        false,
         rad_probe1,
         0,
         grid_step,
@@ -44,7 +45,7 @@ bool Ctrl::unittestExcluded(){
         included_elements,
         3);
 
-    data[i] = current_calculation->generateVolumeData();
+    data[i] = current_calculation->generateData();
     if(data[i].success){
       error[i] = abs(data[i].volumes[0b00000101]-expected_volumes[i])/data[i].volumes[0b00000101];
     }
@@ -88,6 +89,7 @@ bool Ctrl::unittestProtein(){
       false,
       false,
       false,
+      false,
       rad_probe1,
       0,
       grid_step,
@@ -99,7 +101,7 @@ bool Ctrl::unittestProtein(){
       included_elements,
       3);
 
-  data = current_calculation->generateVolumeData();
+  data = current_calculation->generateData();
   if(data.success){
     error_vdwVolume = abs(data.volumes[0b00000011]-expected_vdwVolume)/data.volumes[0b00000011];
     diff_time = data.getTime() - expected_time;
@@ -141,6 +143,7 @@ bool Ctrl::unittestRadius(){
             "./output",
             false,
             false,
+            false,
             two_probe,
             rad_probe1,
             rad_probe2,
@@ -153,7 +156,7 @@ bool Ctrl::unittestRadius(){
             included_elements,
             3);
 
-        data = current_calculation->generateVolumeData();
+        data = current_calculation->generateData();
 
         if(data.success){
           printf("f: %40s, g: %4.2f, d: %4i, r: %4.1f\n", atom_filepath.c_str(), grid_step, max_depth, rad_probe1);
@@ -192,6 +195,7 @@ bool Ctrl::unittest2Probe(){
       "./output",
       false,
       false,
+      false,
       two_probe,
       rad_probe1,
       rad_probe2,
@@ -204,7 +208,7 @@ bool Ctrl::unittest2Probe(){
       included_elements,
       3);
 
-  data = current_calculation->generateVolumeData();
+  data = current_calculation->generateData();
 
   if(data.success){
     printf("f: %40s, g: %4.2f, d: %4i, r1: %4.1f, r2: %4.1f\n", 
@@ -229,6 +233,7 @@ bool Ctrl::unittestSurface(){
   double rad_probe2 = 2;
   double rad_probe1 = 0.5;
   bool two_probe = false;
+  bool surf_areas = true;
   int max_depth = 4;
   double grid_step = 0.1;
 
@@ -243,6 +248,7 @@ bool Ctrl::unittestSurface(){
       "./output",
       false,
       false,
+      surf_areas,
       two_probe,
       rad_probe1,
       rad_probe2,
@@ -255,8 +261,7 @@ bool Ctrl::unittestSurface(){
       included_elements,
       3);
 
-  current_calculation->generateVolumeData();
-  data = current_calculation->generateSurfaceData();
+  data = current_calculation->generateData();
 
   if(data.success){
     printf("f: %40s, g: %4.2f, d: %4i, r1: %4.1f\n", atom_filepath.c_str(), grid_step, max_depth, rad_probe1);

--- a/src/controller_unittest.cpp
+++ b/src/controller_unittest.cpp
@@ -26,7 +26,7 @@ bool Ctrl::unittestExcluded(){
   for (int i = 0; i < 3; i++){
     current_calculation->readAtomsFromFile(atom_filepaths[i], false);
     std::vector<std::string> included_elements = current_calculation->listElementsInStructure();
-    
+
     current_calculation->setParameters(
         atom_filepaths[i],
         "./output",
@@ -211,7 +211,7 @@ bool Ctrl::unittest2Probe(){
   data = current_calculation->generateData();
 
   if(data.success){
-    printf("f: %40s, g: %4.2f, d: %4i, r1: %4.1f, r2: %4.1f\n", 
+    printf("f: %40s, g: %4.2f, d: %4i, r1: %4.1f, r2: %4.1f\n",
         atom_filepath.c_str(), grid_step, max_depth, rad_probe1, rad_probe2);
     printf("vdW: %20.10f, Excluded: %20.10f\n", data.volumes[0b00000011]-28.866, data.volumes[0b00000101]-6.224);
     printf("P1 Core: %20.10f, P1 Shell: %20.10f\n", data.volumes[0b00001001]-0.202, data.volumes[0b00010001]-5.702);
@@ -268,7 +268,7 @@ bool Ctrl::unittestSurface(){
     printf("vdW: %20.10f, Excluded: %20.10f\n", data.volumes[0b00000011]-28.948, data.volumes[0b00000101]-1.86);
     printf("P1 Core: %20.10f, P1 Shell: %20.10f\n", data.volumes[0b00001001]-247.748, data.volumes[0b00010001]-49.124);
     std::vector<double> cav = {294.75,1.34,0.252,0.187,0.187,0.078,0.078};
-    for (int i = 0; i< data.cavities.size(); ++i){
+    for (size_t i = 0; i< data.cavities.size(); ++i){
       printf("Cavity vol: %20.10f A^3\n", data.getCavVolume(i)-cav[i]);
     }
     printf("Time elapsed: %10.5f s\n", data.getTime()-0.83+0.74);

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -122,7 +122,29 @@ CalcReportBundle Model::generateVolumeData(){
 }
 
 CalcReportBundle Model::generateSurfaceData(){
-  // TODO
+  // TODO: add way for this function to tell whether volume calculation has been conducted before
+  auto start = std::chrono::steady_clock::now();
+
+  std::vector<std::vector<char>> solid_types = 
+  { {0b00000011},
+    {0b00000011, 0b00000101},
+    {0b00000011, 0b00000101, 0b00100001, 0b01000001},
+    {0b00000011, 0b00000101, 0b00010001, 0b00100001, 0b01000001}};
+
+  std::vector<bool> for_every_cavity = {false, false, true, true};
+
+//  std::vector<std::vector<double>> surface_areas = _cell.sumSurfArea(solid_types, for_every_cavity);
+
+  _data.surf_vdw = 0; // 0b00000011
+  _data.surf_probe_inaccessible = 0; // 0b00000011 + 0b00000101
+
+  for (Cavity& cav : _data.cavities){
+    cav.surf_shell = 0; // 0b00000011 + 0b00000101 + 0b00100001 + 0b01000001
+    cav.surf_core = 0; // 0b00000011 + 0b00000101 + 0b00010001 + 0b00100001 + 0b01000001
+  }
+
+  auto end = std::chrono::steady_clock::now();
+  _data.addTime(std::chrono::duration<double>(end-start).count());
   return _data;
 }
 

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -37,6 +37,7 @@ bool Model::setParameters(std::string file_path,
             std::string output_dir,
             bool inc_hetatm,
             bool analyze_unit_cell,
+            bool calc_surface_areas,
             bool probe_mode,
             double r_probe1,
             double r_probe2,
@@ -61,6 +62,7 @@ bool Model::setParameters(std::string file_path,
   }
   _data.inc_hetatm = inc_hetatm;
   _data.analyze_unit_cell = analyze_unit_cell;
+  _data.calc_surface_areas = calc_surface_areas;
   _data.grid_step = grid_step;
   _data.max_depth = max_depth;
   _data.make_report = make_report;
@@ -89,8 +91,17 @@ bool Model::setProbeRadii(const double r_1, const double r_2, const bool probe_m
   }
   return true;
 }
-
+  
 // TODO: consider making return value const, in order to prevent controller from messing with this
+CalcReportBundle Model::generateData(){
+  CalcReportBundle data = generateVolumeData();
+  // surface calculation requires running the volume calculation first, but shouldn't be inside the volume calc function
+  if (optionCalcSurfaceAreas() && data.success){
+    data = generateSurfaceData();
+  }
+  return data;
+}
+
 CalcReportBundle Model::generateVolumeData(){
   // save the date and time of calculation for output files
   _time_stamp = timeNow();

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -135,14 +135,14 @@ CalcReportBundle Model::generateSurfaceData(){
 
   std::vector<std::vector<double>> surface_areas = _cell.sumSurfArea(solid_types, for_every_cavity, _data.cavities.size());
 
-  _data.surf_vdw = 0; // 0b00000011
-  _data.surf_probe_inaccessible = 0; // 0b00000011 + 0b00000101
+  _data.surf_vdw = surface_areas[0][0]; // 0b00000011
+  _data.surf_probe_inaccessible = surface_areas[1][0]; // 0b00000011 + 0b00000101
 
   for (Cavity& cav : _data.cavities){
-    cav.surf_shell = 0; // 0b00000011 + 0b00000101 + 0b00100001 + 0b01000001
-    cav.surf_core = 0; // 0b00000011 + 0b00000101 + 0b00010001 + 0b00100001 + 0b01000001
+    cav.surf_shell = surface_areas[2][cav.id-1]; // 0b00000011 + 0b00000101 + 0b00100001 + 0b01000001
+    cav.surf_core = surface_areas[3][cav.id-1]; // 0b00000011 + 0b00000101 + 0b00010001 + 0b00100001 + 0b01000001
   }
-
+  
   auto end = std::chrono::steady_clock::now();
   _data.addTime(std::chrono::duration<double>(end-start).count());
   return _data;

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -133,7 +133,7 @@ CalcReportBundle Model::generateSurfaceData(){
 
   std::vector<bool> for_every_cavity = {false, false, true, true};
 
-  std::vector<std::vector<double>> surface_areas = _cell.sumSurfArea(solid_types, for_every_cavity);
+  std::vector<std::vector<double>> surface_areas = _cell.sumSurfArea(solid_types, for_every_cavity, _data.cavities.size());
 
   _data.surf_vdw = 0; // 0b00000011
   _data.surf_probe_inaccessible = 0; // 0b00000011 + 0b00000101

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -91,7 +91,7 @@ bool Model::setProbeRadii(const double r_1, const double r_2, const bool probe_m
   }
   return true;
 }
-  
+
 // TODO: consider making return value const, in order to prevent controller from messing with this
 CalcReportBundle Model::generateData(){
   CalcReportBundle data = generateVolumeData();
@@ -136,7 +136,9 @@ CalcReportBundle Model::generateSurfaceData(){
   // TODO: add way for this function to tell whether volume calculation has been conducted before
   auto start = std::chrono::steady_clock::now();
 
-  std::vector<std::vector<char>> solid_types = 
+  // TODO: consider using inverse values in last two vectors to keep vector size smaller than 4. It might help with the find() function
+  // TODO: consider making different solid_types for each probe mode
+  std::vector<std::vector<char>> solid_types =
   { {0b00000011},
     {0b00000011, 0b00000101},
     {0b00000011, 0b00000101, 0b00100001, 0b01000001},
@@ -153,7 +155,7 @@ CalcReportBundle Model::generateSurfaceData(){
     cav.surf_shell = surface_areas[2][cav.id-1]; // 0b00000011 + 0b00000101 + 0b00100001 + 0b01000001
     cav.surf_core = surface_areas[3][cav.id-1]; // 0b00000011 + 0b00000101 + 0b00010001 + 0b00100001 + 0b01000001
   }
-  
+
   auto end = std::chrono::steady_clock::now();
   _data.addTime(std::chrono::duration<double>(end-start).count());
   return _data;

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -9,6 +9,25 @@
 #include <string>
 #include <vector>
 
+//////////////////////
+// CALCRESULTBUNDLE //
+//////////////////////
+
+std::array<double,3> CalcReportBundle::getCavCentre(const unsigned char i){
+  std::array<double,3> cav_ctr;
+  for (char j = 0; j < 3; ++j){
+    cav_ctr[j] = (cavities[i].min_bound[j] + cavities[i].max_bound[j])/2;
+  }
+  return cav_ctr;
+}
+
+double CalcReportBundle::getTime(){
+  double total_seconds = 0;
+  for (const double time : elapsed_seconds){
+    total_seconds += time;
+  }
+  return total_seconds;
+}
 
 ////////////////////////////////////
 // CONTROLLER-MODEL COMMUNICATION //
@@ -103,6 +122,7 @@ CalcReportBundle Model::generateVolumeData(){
 }
 
 CalcReportBundle Model::generateSurfaceData(){
+  // TODO
   return _data;
 }
 

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -99,8 +99,11 @@ CalcReportBundle Model::generateVolumeData(){
   auto end = std::chrono::steady_clock::now();
   _data.addTime(std::chrono::duration<double>(end-start).count());
 
-  // create a report bundle
   return calcVolume();
+}
+
+CalcReportBundle Model::generateSurfaceData(){
+  return _data;
 }
 
 void Model::setAtomListForCalculation(){

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -133,7 +133,7 @@ CalcReportBundle Model::generateSurfaceData(){
 
   std::vector<bool> for_every_cavity = {false, false, true, true};
 
-//  std::vector<std::vector<double>> surface_areas = _cell.sumSurfArea(solid_types, for_every_cavity);
+  std::vector<std::vector<double>> surface_areas = _cell.sumSurfArea(solid_types, for_every_cavity);
 
   _data.surf_vdw = 0; // 0b00000011
   _data.surf_probe_inaccessible = 0; // 0b00000011 + 0b00000101

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -410,7 +410,6 @@ std::vector<std::vector<double>> Space::sumSurfArea(const std::vector<std::vecto
             getVxlFromGrid(x+1,y+1,z+1,lvl)},
           surface_areas,
           for_every_cavity);
-        printBinary(getVxlFromGrid(x,y,z,0).getType());
       }
     }
   }

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -384,9 +384,14 @@ void Space::tallyVoxelsUnitCell(std::array<unsigned int,3> bot_lvl_index,
 // SURFACE AREA //
 //////////////////
 
-std::vector<std::vector<double>> Space::sumSurfArea(const std::vector<std::vector<char>>& solid_types, const std::vector<bool>& for_every_cavity){
+std::vector<std::vector<double>> Space::sumSurfArea(const std::vector<std::vector<char>>& solid_types, const std::vector<bool>& for_every_cavity, const unsigned char n_cavities){
   assert(solid_types.size() == for_every_cavity.size());
+  // allocate memory
   std::vector<std::vector<double>> surface_areas(solid_types.size());
+  for (char i = 0; i < surface_areas.size(); ++i){
+    surface_areas[i] = std::vector<double> (for_every_cavity[i]? n_cavities : 1);
+  }
+
   return surface_areas;
 }
 

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -339,8 +339,8 @@ void Space::getUnitCellVolume(std::map<char,double>& volumes,
       min_index_arr[i] = id_min[id][i];
       max_index_arr[i] = id_max[id][i];
     }
-    cavities.push_back(Cavity(id, 
-                       tally*unit_volume, 
+    cavities.push_back(Cavity(id,
+                       tally*unit_volume,
                        id_shell_tally[id] * unit_volume,
                        min_arr,
                        max_arr,
@@ -394,7 +394,7 @@ std::vector<std::vector<double>> Space::sumSurfArea(const std::vector<std::vecto
   assert(solid_types.size() == for_every_cavity.size());
   // allocate memory
   std::vector<std::vector<double>> surface_areas(solid_types.size());
-  for (char i = 0; i < surface_areas.size(); ++i){
+  for (size_t i = 0; i < surface_areas.size(); ++i){
     surface_areas[i] = std::vector<double> (for_every_cavity[i]? n_cavities : 1);
   }
 
@@ -446,7 +446,7 @@ void evalCubeMultiSurface(const std::array<Voxel,8> vertices, std::vector<std::v
           surface_areas[i][id-1] += SurfaceLUT::typeToArea(SurfaceLUT::configToType(surf_config)) * tally/total;
         }
       }
-      /*
+      /* TODO: remove if unused
       for (unsigned char cav_id = 1; cav_id <= surface_areas[i].size(); ++cav_id){ // AVOID THIS LOOP
         //unsigned char surf_config = evalSurfConfig(vertices, solid_types[i], cav_id);
         unsigned char surf_config = 0;
@@ -692,7 +692,10 @@ void Space::printGrid(){
 ///////////////////////////
 
 const constexpr std::array<unsigned char,256> SurfaceLUT::types_by_config = {1,2,2,3,2,3,4,6,2,4,3,6,3,6,6,9,2,3,4,6,4,6,8,10,5,7,7,13,7,13,11,6,2,4,3,6,5,7,7,13,4,8,6,10,7,11,13,6,3,6,6,9,7,13,11,6,7,11,13,6,12,7,7,3,2,4,5,7,3,6,7,13,4,8,7,11,6,10,13,6,3,6,7,13,6,9,11,6,7,11,12,7,13,6,7,3,4,8,7,11,7,11,12,7,8,14,11,8,11,8,7,4,6,10,13,6,13,6,7,3,11,8,7,4,7,4,5,2,2,5,4,7,4,7,8,11,3,7,6,13,6,13,10,6,4,7,8,11,8,11,14,8,7,12,11,7,11,7,8,4,3,7,6,13,7,12,11,7,6,11,9,6,13,7,6,3,6,13,10,6,11,7,8,4,13,7,6,3,7,5,4,2,3,7,7,12,6,13,11,7,6,11,13,7,9,6,6,3,6,13,11,7,10,6,8,4,13,7,7,5,6,3,4,2,6,11,13,7,13,7,7,5,10,8,6,4,6,4,3,2,9,6,6,3,6,3,4,2,6,4,3,2,3,2,2,1};
-const constexpr std::array<double, 15> SurfaceLUT::area_by_config = {0,0,0.21650635,0.707106781,0.4330127,0.4330127,1.149451549,0.923613131,0.64951905,1,1.299,1.365957899,1.414213562,0,0.8660254};
+// Theoretical values from https://doi.org/10.1007/978-3-540-39966-7_33
+// const constexpr std::array<double, 15> SurfaceLUT::area_by_config = {0,0,0.2118,0.669,0.4236,0.4236,0.9779,0.8808,0.6354,0.927,1.2706,1.1897,1.338,1.5731,0.8472};
+// Semi-empirical values from https://doi.org/10.1016/j.imavis.2004.06.012
+const constexpr std::array<double, 15> SurfaceLUT::area_by_config = {0,0,0.636,0.669,1.272,1.272,0.5537,1.305,1.908,0.927,0.4222,1.1897,1.338,1.5731,2.544};
 unsigned char SurfaceLUT::configToType(unsigned char config) {
   return types_by_config[config];
 }

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -384,6 +384,8 @@ void Space::tallyVoxelsUnitCell(std::array<unsigned int,3> bot_lvl_index,
 // SURFACE AREA //
 //////////////////
 
+void evalCube(const std::array<Voxel,8>, std::vector<std::vector<double>>&, const std::vector<bool>&);
+
 std::vector<std::vector<double>> Space::sumSurfArea(const std::vector<std::vector<char>>& solid_types, const std::vector<bool>& for_every_cavity, const unsigned char n_cavities){
   assert(solid_types.size() == for_every_cavity.size());
   // allocate memory
@@ -392,7 +394,32 @@ std::vector<std::vector<double>> Space::sumSurfArea(const std::vector<std::vecto
     surface_areas[i] = std::vector<double> (for_every_cavity[i]? n_cavities : 1);
   }
 
+  constexpr char lvl = 0;
+  std::array<unsigned long,3> n_vxl = gridstepsOnLvl(lvl);
+  for (unsigned x = 0; x < n_vxl[0]-1; ++x){
+    for (unsigned y = 0; y < n_vxl[1]-1; ++y){
+      for (unsigned z = 0; z < n_vxl[2]-1; ++z){
+        // TODO: consider passing voxels by reference rather than value
+        evalCube({getVxlFromGrid(x,y,z,lvl),
+            getVxlFromGrid(x+1,y,z,lvl),
+            getVxlFromGrid(x,y+1,z,lvl),
+            getVxlFromGrid(x+1,y+1,z,lvl),
+            getVxlFromGrid(x,y,z+1,lvl),
+            getVxlFromGrid(x+1,y,z+1,lvl),
+            getVxlFromGrid(x,y+1,z+1,lvl),
+            getVxlFromGrid(x+1,y+1,z+1,lvl)},
+          surface_areas,
+          for_every_cavity);
+        printBinary(getVxlFromGrid(x,y,z,0).getType());
+      }
+    }
+  }
+
   return surface_areas;
+}
+
+void evalCube(const std::array<Voxel,8> vertices, std::vector<std::vector<double>>& surface_areas, const std::vector<bool>& for_every_cavity){
+
 }
 
 //////////////////////
@@ -493,6 +520,7 @@ unsigned long int Space::totalVxlOnLvl(const int lvl) const{
   return total;
 }
 
+// TODO: read this value from Container3D and remove n_gridsteps entirely
 const std::array<unsigned long int,3> Space::gridstepsOnLvl(const int level) const {
   if (level > max_depth){throw ExceptIllegalFunctionCall();}
   std::array<unsigned long int,3> n_voxels;

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -434,7 +434,7 @@ void evalCubeMultiSurface(const std::array<Voxel,8> vertices, std::vector<std::v
         for (char j = 0; j < 8; ++j){
           setBit(surf_config, j, isSolid(vertices[j], solid_types[i], cav_id));
         }
-        //surface_areas[i][cav_id-1] += TypeToArea(configToType(surf_config));
+        //surface_areas[i][cav_id-1] += typeToArea(configToType(surf_config));
       }
     }
     else {
@@ -443,7 +443,7 @@ void evalCubeMultiSurface(const std::array<Voxel,8> vertices, std::vector<std::v
         setBit(surf_config, j, isSolid(vertices[j], solid_types[i]));
       }
       
-      //surface_areas[i][0] += TypeToArea(configToType(surf_config));
+      surface_areas[i][0] += SurfaceLUT::typeToArea(SurfaceLUT::configToType(surf_config));
     }
   }
 }
@@ -666,4 +666,17 @@ void Space::printGrid(){
     std::cout << "INPUT: ";
     std::cin >> usr_inp;
   }
+}
+
+///////////////////////////
+// SURFACE LOOK UP TABLE //
+///////////////////////////
+
+const constexpr std::array<unsigned char,256> SurfaceLUT::types_by_config = {1,2,2,3,2,3,4,6,2,4,3,6,3,6,6,9,2,3,4,6,4,6,8,10,5,7,7,13,7,13,11,6,2,4,3,6,5,7,7,13,4,8,6,10,7,11,13,6,3,6,6,9,7,13,11,6,7,11,13,6,12,7,7,3,2,4,5,7,3,6,7,13,4,8,7,11,6,10,13,6,3,6,7,13,6,9,11,6,7,11,12,7,13,6,7,3,4,8,7,11,7,11,12,7,8,14,11,8,11,8,7,4,6,10,13,6,13,6,7,3,11,8,7,4,7,4,5,2,2,5,4,7,4,7,8,11,3,7,6,13,6,13,10,6,4,7,8,11,8,11,14,8,7,12,11,7,11,7,8,4,3,7,6,13,7,12,11,7,6,11,9,6,13,7,6,3,6,13,10,6,11,7,8,4,13,7,6,3,7,5,4,2,3,7,7,12,6,13,11,7,6,11,13,7,9,6,6,3,6,13,11,7,10,6,8,4,13,7,7,5,6,3,4,2,6,11,13,7,13,7,7,5,10,8,6,4,6,4,3,2,9,6,6,3,6,3,4,2,6,4,3,2,3,2,2,1};
+const constexpr std::array<double, 15> SurfaceLUT::area_by_config = {0,0,0.21650635,0.707106781,0.4330127,0.4330127,1.149451549,0.923613131,0.64951905,1,1.299,1.365957899,1.414213562,0,0.8660254};
+unsigned char SurfaceLUT::configToType(unsigned char config) {
+  return types_by_config[config];
+}
+double SurfaceLUT::typeToArea(unsigned char type) {
+  return area_by_config[type];
 }

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -446,16 +446,6 @@ void evalCubeMultiSurface(const std::array<Voxel,8> vertices, std::vector<std::v
           surface_areas[i][id-1] += SurfaceLUT::typeToArea(SurfaceLUT::configToType(surf_config)) * tally/total;
         }
       }
-      /* TODO: remove if unused
-      for (unsigned char cav_id = 1; cav_id <= surface_areas[i].size(); ++cav_id){ // AVOID THIS LOOP
-        //unsigned char surf_config = evalSurfConfig(vertices, solid_types[i], cav_id);
-        unsigned char surf_config = 0;
-        for (char j = 0; j < 8; ++j){
-          setBit(surf_config, j, isSolid(vertices[j], solid_types[i], cav_id));
-        }
-        surface_areas[i][cav_id-1] += SurfaceLUT::typeToArea(SurfaceLUT::configToType(surf_config));
-      }
-      */
     }
     else {
       unsigned char surf_config = 0;

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -418,7 +418,13 @@ std::vector<std::vector<double>> Space::sumSurfArea(const std::vector<std::vecto
     }
   }
 
-  // TODO: multiply every surface area value by the square of voxel side length
+  for (auto& area_type : surface_areas){
+    for (auto& area_value : area_type){
+      area_value *= getVxlSize()*getVxlSize();
+//      std::cout << area_value << std::endl;
+    }
+//    std::cout << std::endl;
+  }
 
   return surface_areas;
 }
@@ -428,13 +434,15 @@ void evalCubeMultiSurface(const std::array<Voxel,8> vertices, std::vector<std::v
   for (size_t i = 0; i < surface_areas.size(); ++i){
 
     if (for_every_cavity[i]) {
+      // TODO: issue in this section: different cavities are not handeled properly as not only the IDs of bit 1 voxels
+      // but also the IDs of bit 2 voxels need to be taken into account
       for (unsigned char cav_id = 1; cav_id <= surface_areas[i].size(); ++cav_id){
         //unsigned char surf_config = evalSurfConfig(vertices, solid_types[i], cav_id);
         unsigned char surf_config = 0;
         for (char j = 0; j < 8; ++j){
           setBit(surf_config, j, isSolid(vertices[j], solid_types[i], cav_id));
         }
-        //surface_areas[i][cav_id-1] += typeToArea(configToType(surf_config));
+        surface_areas[i][cav_id-1] += SurfaceLUT::typeToArea(SurfaceLUT::configToType(surf_config));
       }
     }
     else {
@@ -442,14 +450,13 @@ void evalCubeMultiSurface(const std::array<Voxel,8> vertices, std::vector<std::v
       for (char j = 0; j < 8; ++j){
         setBit(surf_config, j, isSolid(vertices[j], solid_types[i]));
       }
-      
       surface_areas[i][0] += SurfaceLUT::typeToArea(SurfaceLUT::configToType(surf_config));
     }
   }
 }
 
 bool isSolid(const Voxel& vxl, const std::vector<char>& solid_types, const unsigned char id){
-  if (vxl.getID() == id) {
+  if (vxl.getID() == id) { // THIS LINE IS WRONG
     return std::find(solid_types.begin(), solid_types.end(), vxl.getType()) != solid_types.end();
   }
   return false;

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -380,6 +380,16 @@ void Space::tallyVoxelsUnitCell(std::array<unsigned int,3> bot_lvl_index,
   }
 }
 
+//////////////////
+// SURFACE AREA //
+//////////////////
+
+std::vector<std::vector<double>> Space::sumSurfArea(const std::vector<std::vector<char>>& solid_types, const std::vector<bool>& for_every_cavity){
+  assert(solid_types.size() == for_every_cavity.size());
+  std::vector<std::vector<double>> surface_areas(solid_types.size());
+  return surface_areas;
+}
+
 //////////////////////
 // ACCESS FUNCTIONS //
 //////////////////////

--- a/src/special_chars.cpp
+++ b/src/special_chars.cpp
@@ -7,6 +7,10 @@ std::wstring Symbol::angstrom(){
   return L"\u212B";
 }
 
+std::wstring Symbol::squared(){
+  return L"\u00B2";
+}
+
 std::wstring Symbol::cubed(){
   return L"\u00B3";
 }

--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -552,6 +552,7 @@ void Voxel::tallyVoxelsOfType(std::map<char,unsigned>& type_tally,
   // if voxel is of type "mixed" (i.e. data vector is not empty)
   if(hasSubvoxel()){
     // then total number of voxels is given by tallying all subvoxels
+    // TODO remove if unneeded
     unsigned int total = 0;
     std::array<unsigned,3> sub_index;
     for(char x = 0; x < 2; ++x){

--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -174,12 +174,12 @@ bool Voxel::isCore(){return readBit(_type,3);}
 bool Voxel::isAssigned(){return readBit(_type,0);}
 
 // type
-char Voxel::getType(){return _type;}
+char Voxel::getType() const {return _type;}
 void Voxel::setType(char input){_type = input;}
 
 // ID
 void Voxel::setID(unsigned char id){_identity = id;}
-unsigned char Voxel::getID(){return _identity;}
+unsigned char Voxel::getID() const {return _identity;}
 
 /////////////////////////////////
 // TYPE ASSIGNMENT PREPARATION //


### PR DESCRIPTION
Implemented the surface area calculation. Surface areas for individual cavities as well as the whole structure can now be calculated and are displayed in the UI.

Notes:
* Currently, the surface areas overestimate the analytical value, at least when testing a single spherical atom (r=1.2, r=2.4). This may be adjusted by changing the weights for surface configurations found in the LUT definition in space.cpp
* The number of outputs has reached a point where the simple text output box is insufficient for clear data display. It may make sense to rethink the output panel. One way to handle this is to display the cavity information as a table
* The surface calculation has not been optimised in favour of implementing all features and producing a minimum viable product. There are sure to be ways to accelerate the algorithm