### PR TITLE
Diagonal search

### DIFF
--- a/include/controller.h
+++ b/include/controller.h
@@ -27,6 +27,7 @@ class Ctrl{
     bool unittestRadius();
     bool unittest2Probe();
     bool unittestSurface();
+    bool unittestFloodfill();
 
   private:
     // consider making static pointer for model

--- a/include/voxel.h
+++ b/include/voxel.h
@@ -101,8 +101,8 @@ class Voxel{
     // atom vs core
     bool isAtom(const Atom&, const Vector&, const double, const double);
     // cavity id
-    void descend(std::vector<VoxelLoc>&, const unsigned char, const std::array<unsigned,3>&, const int, const signed char, const bool);
-    void ascend(std::vector<VoxelLoc>&, const unsigned char, const std::array<unsigned,3>, const int, std::array<unsigned,3>, const signed char);
+    void descend(std::vector<VoxelLoc>&, const unsigned char, const std::array<unsigned,3>&, const int, const std::array<int,3>&);
+    void ascend(std::vector<VoxelLoc>&, const unsigned char, const std::array<unsigned,3>, const int, std::array<unsigned,3>, const std::array<int,3>&);
     void passIDtoChildren(const std::array<unsigned,3>&, const int);
     // shell vs void
     bool searchForCore(const std::array<unsigned int,3>&, const unsigned, bool=false);

--- a/src/base_init.cpp
+++ b/src/base_init.cpp
@@ -48,6 +48,9 @@ bool MainApp::OnInit()
     else if (unittest_id=="surface"){
       Ctrl::getInstance()->unittestSurface();
     }
+    else if (unittest_id=="floodfill"){
+      Ctrl::getInstance()->unittestFloodfill();
+    }
     else {
       std::cout << "Invalid selection" << std::endl;}
     return true;

--- a/src/controller_unittest.cpp
+++ b/src/controller_unittest.cpp
@@ -279,3 +279,59 @@ bool Ctrl::unittestSurface(){
   }
   return true;
 }
+
+bool Ctrl::unittestFloodfill(){
+  if(current_calculation == NULL){current_calculation = new Model();}
+
+  // parameters for unittest:
+  const std::string atom_filepath = "./inputfile/Pd6L4_open_cage_Fujita.xyz";
+  const std::string radius_filepath = "./inputfile/radii.txt";
+  double rad_probe2 = 4;
+  double rad_probe1 = 1.2;
+  bool two_probe = true;
+  bool surf_areas = false;
+  int max_depth = 4;
+  double grid_step = 0.3;
+
+  std::unordered_map<std::string, double> rad_map = current_calculation->importRadiusMap(radius_filepath);
+
+  CalcReportBundle data;
+  current_calculation->readAtomsFromFile(atom_filepath, false);
+  std::vector<std::string> included_elements = current_calculation->listElementsInStructure();
+
+  current_calculation->setParameters(
+      atom_filepath,
+      "./output",
+      false,
+      false,
+      surf_areas,
+      two_probe,
+      rad_probe1,
+      rad_probe2,
+      grid_step,
+      max_depth,
+      false,
+      false,
+      false,
+      rad_map,
+      included_elements,
+      3);
+
+  data = current_calculation->generateData();
+
+  if(data.success){
+    printf("f: %40s, g: %4.2f, d: %4i, r1: %4.1f\n", atom_filepath.c_str(), grid_step, max_depth, rad_probe1);
+    printf("vdW: %20.10f, Excluded: %20.10f\n", data.volumes[0b00000011]-28.948, data.volumes[0b00000101]-1.86);
+    printf("P1 Core: %20.10f, P1 Shell: %20.10f\n", data.volumes[0b00001001]-247.748, data.volumes[0b00010001]-49.124);
+    //std::vector<double> cav = {294.75,1.34,0.252,0.187,0.187,0.078,0.078};
+    for (size_t i = 0; i< data.cavities.size(); ++i){
+      //printf("Cavity vol: %20.10f A^3\n", data.getCavVolume(i)-cav[i]);
+      printf("Cavity vol: %20.10f A^3\n", data.getCavVolume(i));
+    }
+    printf("Time elapsed: %10.5f s\n", data.getTime()-0.83+0.74);
+  }
+  else{
+    std::cout << "Calculation failed" << std::endl;
+  }
+  return true;
+}

--- a/src/controller_unittest.cpp
+++ b/src/controller_unittest.cpp
@@ -267,9 +267,10 @@ bool Ctrl::unittestSurface(){
     printf("f: %40s, g: %4.2f, d: %4i, r1: %4.1f\n", atom_filepath.c_str(), grid_step, max_depth, rad_probe1);
     printf("vdW: %20.10f, Excluded: %20.10f\n", data.volumes[0b00000011]-28.948, data.volumes[0b00000101]-1.86);
     printf("P1 Core: %20.10f, P1 Shell: %20.10f\n", data.volumes[0b00001001]-247.748, data.volumes[0b00010001]-49.124);
-    std::vector<double> cav = {294.75,1.34,0.252,0.187,0.187,0.078,0.078};
+    //std::vector<double> cav = {294.75,1.34,0.252,0.187,0.187,0.078,0.078};
     for (size_t i = 0; i< data.cavities.size(); ++i){
-      printf("Cavity vol: %20.10f A^3\n", data.getCavVolume(i)-cav[i]);
+      //printf("Cavity vol: %20.10f A^3\n", data.getCavVolume(i)-cav[i]);
+      printf("Cavity vol: %20.10f A^3\n", data.getCavVolume(i));
     }
     printf("Time elapsed: %10.5f s\n", data.getTime()-0.83+0.74);
   }

--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -385,6 +385,7 @@ bool Voxel::floodFill(const unsigned char id, const std::array<unsigned,3>& star
   flood_stack.push_back(VoxelLoc(start_index, start_lvl));
 
   std::vector<std::vector<std::array<int,3>>> neighbour_indices = SearchIndex().computeIndices(3);
+  // TODO: remove the first element {0,0,0}
 
   // adds neighbours to the stack, IDs are assigned before adding to the stack
   while (flood_stack.size() > 0){
@@ -392,27 +393,10 @@ bool Voxel::floodFill(const unsigned char id, const std::array<unsigned,3>& star
     flood_stack.pop_back();
 
     std::array<unsigned,3> nb_index;
-/*
-    26
-    1 0 0
-    0 1 0 x 2
-    0 0 1 x 2
-    1 1 0 x 4
-    1 0 1 x 4
-    0 1 1 x 4
-    1 1 1 x 8
-    */
-
     for (const auto& shell : neighbour_indices){
       for (const auto& rel_index : shell){
-/*
-    for (char dim = 0; dim < 3; dim++){
-      for (bool sign : {false, true}){ // true: negative, false: positive
-      */
         
         nb_index = add(vxl.index, rel_index);
-//        nb_index = vxl.index;
- //       nb_index[dim] += sign? -1 : 1;
         if (!s_cell->isInBounds(nb_index,vxl.lvl)){continue;} // skip if index is invalid
         Voxel& nb_vxl = s_cell->getVxlFromGrid(nb_index,vxl.lvl);
         if (!nb_vxl.isCore()) {continue;} // skip if neighbour is not core

--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -441,7 +441,7 @@ void Voxel::descend(std::vector<VoxelLoc>& stack, const unsigned char id, const 
         loop_i[dim] = {0,1};
       }
     }
-    
+
     for (char i : loop_i[0]){
       sub_index[0] = index[0] * 2 + i;
       for (char j : loop_i[1]){
@@ -463,7 +463,7 @@ void Voxel::ascend(std::vector<VoxelLoc>& stack, const unsigned char id, const s
   bool same_vxl = false;
   for (char dim = 0; dim < 3; ++dim){
     if (!nb_relation[dim]){
-      same_vxl &= index[dim]/2 == prev_index[dim]/2;
+      same_vxl &= (index[dim]/2 == prev_index[dim]/2);
     }
   }
 

--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -384,27 +384,46 @@ bool Voxel::floodFill(const unsigned char id, const std::array<unsigned,3>& star
   std::vector<VoxelLoc> flood_stack;
   flood_stack.push_back(VoxelLoc(start_index, start_lvl));
 
+  std::vector<std::vector<std::array<int,3>>> neighbour_indices = SearchIndex().computeIndices(3);
+
   // adds neighbours to the stack, IDs are assigned before adding to the stack
   while (flood_stack.size() > 0){
     VoxelLoc vxl = flood_stack.back();
     flood_stack.pop_back();
 
     std::array<unsigned,3> nb_index;
+/*
+    26
+    1 0 0
+    0 1 0 x 2
+    0 0 1 x 2
+    1 1 0 x 4
+    1 0 1 x 4
+    0 1 1 x 4
+    1 1 1 x 8
+    */
+
+    for (const auto& shell : neighbour_indices){
+      for (const auto& rel_index : shell){
+/*
     for (char dim = 0; dim < 3; dim++){
       for (bool sign : {false, true}){ // true: negative, false: positive
-        nb_index = vxl.index;
-        nb_index[dim] += sign? -1 : 1;
+      */
+        
+        nb_index = add(vxl.index, rel_index);
+//        nb_index = vxl.index;
+ //       nb_index[dim] += sign? -1 : 1;
         if (!s_cell->isInBounds(nb_index,vxl.lvl)){continue;} // skip if index is invalid
         Voxel& nb_vxl = s_cell->getVxlFromGrid(nb_index,vxl.lvl);
         if (!nb_vxl.isCore()) {continue;} // skip if neighbour is not core
 
         if (nb_vxl.hasSubvoxel()){
           // descend to all subvoxels that border this voxel and add to stack
-          nb_vxl.descend(flood_stack, id, nb_index, vxl.lvl, dim, sign);
+          nb_vxl.descend(flood_stack, id, nb_index, vxl.lvl, rel_index);
         }
         else {
           // ascend to highest parent of pure type and add to stack
-          nb_vxl.ascend(flood_stack, id, nb_index, vxl.lvl, vxl.index, dim);
+          nb_vxl.ascend(flood_stack, id, nb_index, vxl.lvl, vxl.index, rel_index);
         }
       }
     }
@@ -412,7 +431,7 @@ bool Voxel::floodFill(const unsigned char id, const std::array<unsigned,3>& star
   return true;
 }
 
-void Voxel::descend(std::vector<VoxelLoc>& stack, const unsigned char id, const std::array<unsigned,3>& index, const int lvl, const signed char dim, const bool sign){
+void Voxel::descend(std::vector<VoxelLoc>& stack, const unsigned char id, const std::array<unsigned,3>& index, const int lvl, const std::array<int,3>& nb_relation){
   if (!isCore()){return;} // return immediatly if voxel isn't and doesn't contain core voxel
   if (!hasSubvoxel()){
     if (getID() == 0){
@@ -425,24 +444,46 @@ void Voxel::descend(std::vector<VoxelLoc>& stack, const unsigned char id, const 
   else {
     // only loop over those voxels bordering the previous voxel
     std::array<unsigned,3> sub_index;
-    std::array<signed char,3> i;
-    i[dim] = sign? 1 : 0;
-    for (i[(dim+1)%3] = 0; i[(dim+1)%3] < 2; ++i[(dim+1)%3]){
-      for (i[(dim+2)%3] = 0; i[(dim+2)%3] < 2; ++i[(dim+2)%3]){
-        for (char j = 0; j < 3; ++j){
-          sub_index[j] = index[j] * 2 + i[j];
+
+    // the subvoxels that need to be added to the flood fill stack are determined by the relation of the previous
+    // voxel and the current voxel. the following block evaluates the relation to determine, which subvoxels to
+    // loop through
+    std::array<std::vector<char>,3> loop_i;
+    for (char dim = 0; dim < 3; ++ dim){
+      if (nb_relation[dim]){
+        loop_i[dim] = {static_cast<char>((nb_relation[dim] > 0)? 0 : 1)};
+      }
+      else {
+        loop_i[dim] = {0,1};
+      }
+    }
+    
+    for (char i : loop_i[0]){
+      sub_index[0] = index[0] * 2 + i;
+      for (char j : loop_i[1]){
+        sub_index[1] = index[1] * 2 + j;
+        for (char k : loop_i[2]){
+          sub_index[2] = index[2] * 2 + k;
+          s_cell->getVxlFromGrid(sub_index, lvl-1).descend(stack, id, sub_index, lvl-1, nb_relation);
         }
-        s_cell->getVxlFromGrid(sub_index, lvl-1).descend(stack, id, sub_index, lvl-1, dim, sign);
       }
     }
   }
 }
 
-void Voxel::ascend(std::vector<VoxelLoc>& stack, const unsigned char id, const std::array<unsigned,3> index, const int lvl, std::array<unsigned,3> prev_index, const signed char dim){
+void Voxel::ascend(std::vector<VoxelLoc>& stack, const unsigned char id, const std::array<unsigned,3> index, const int lvl, std::array<unsigned,3> prev_index, const std::array<int,3>& nb_relation){
   // compare index with index of previous voxel
   // if voxel and previous voxel dont't belong to the same parent and this is not top lvl vxl
   // then compare types of this voxel and parent voxel
-  if (index[dim]/2 != prev_index[dim]/2 && lvl != s_cell->getMaxDepth()){
+  
+  bool same_vxl = false;
+  for (char dim = 0; dim < 3; ++dim){
+    if (!nb_relation[dim]){
+      same_vxl &= index[dim]/2 == prev_index[dim]/2;
+    }
+  }
+
+  if (same_vxl && lvl != s_cell->getMaxDepth()){
     std::array<unsigned,3> parent_index;
     for (char i = 0; i < 3; ++i){
       parent_index[i] = index[i]/2;
@@ -452,7 +493,7 @@ void Voxel::ascend(std::vector<VoxelLoc>& stack, const unsigned char id, const s
     Voxel& parent = s_cell->getVxlFromGrid(parent_index, lvl+1);
     // if types are the same, then move to parent voxel
     if (parent.getType() == getType()){
-      parent.ascend(stack, id, parent_index, lvl+1, prev_index, dim);
+      parent.ascend(stack, id, parent_index, lvl+1, prev_index, nb_relation);
       return;
     }
   }

--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -467,7 +467,7 @@ void Voxel::ascend(std::vector<VoxelLoc>& stack, const unsigned char id, const s
     }
   }
 
-  if (same_vxl && lvl != s_cell->getMaxDepth()){
+  if (!same_vxl && lvl != s_cell->getMaxDepth()){
     std::array<unsigned,3> parent_index;
     for (char i = 0; i < 3; ++i){
       parent_index[i] = index[i]/2;

--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -385,7 +385,7 @@ bool Voxel::floodFill(const unsigned char id, const std::array<unsigned,3>& star
   flood_stack.push_back(VoxelLoc(start_index, start_lvl));
 
   std::vector<std::vector<std::array<int,3>>> neighbour_indices = SearchIndex().computeIndices(3);
-  // TODO: remove the first element {0,0,0}
+  neighbour_indices.erase(neighbour_indices.begin());
 
   // adds neighbours to the stack, IDs are assigned before adding to the stack
   while (flood_stack.size() > 0){


### PR DESCRIPTION
Improves the observed fracture of cavities that occurs when only direct neighbours are taken into accounts during the flood fill algorithm. These changes to the flood fill algorithm cause the diagonal neighbours (26 neighbours in total) to be included.