### PR TITLE
fix rounding error

### DIFF
--- a/src/space.cpp
+++ b/src/space.cpp
@@ -358,7 +358,7 @@ void Space::setUnitCellIndexes(){
     // +0.5 to avoid rounding errors
     _unit_cell_start_index[i] = int(0.5 - _cart_min[i]/_grid_size);
     // no rounding because _unit_cell_mod_index will correct any rounding error in _unit_cell_end_index
-    _unit_cell_end_index[i] = _unit_cell_start_index[i] + (_unit_cell_limits[i]/_grid_size);
+    _unit_cell_end_index[i] = _unit_cell_start_index[i] + int(_unit_cell_limits[i]/_grid_size);
     // warning: std::fmod() provided a wrong value in some cases so the fmod calculation is done manually
     _unit_cell_mod_index[i] = custom_fmod(_unit_cell_limits[i],_grid_size) / _grid_size;
    }


### PR DESCRIPTION
An implicit type cast caused rounding errors in rare cases in such a way that the number of voxels for a unit cell did not match the real values.
Indeed, when `(_unit_cell_limits[i]/_grid_size)` was close to an integer, the truncating of `(_unit_cell_limits[i]/_grid_size)` and `_unit_cell_start_index[i] + (_unit_cell_limits[i]/_grid_size)` was not always matching.
With this explicit type cast `_unit_cell_start_index[i] + int(_unit_cell_limits[i]/_grid_size)`, the end_index and mod_index should always be correctly calculated in limit cases (i.e. +1 for end_index and 0 for mod_index or +0 for end_index and 1 for mod_index).