### PR TITLE
Fix Memory leaks

### DIFF
--- a/include/atom.h
+++ b/include/atom.h
@@ -3,7 +3,7 @@
 #define ATOM_H
 
 #include "vector.h"
-#include "exception.h"
+#include <exception>
 #include <vector>
 #include <array>
 #include <iostream>
@@ -35,7 +35,7 @@ struct Atom{
       case 1: return pos_y;
       case 2: return pos_z;
     }
-    throw ExceptIllegalFunctionCall();
+    throw std::invalid_argument("");
   }
 
   void print(){

--- a/include/atom.h
+++ b/include/atom.h
@@ -3,6 +3,7 @@
 #define ATOM_H
 
 #include "vector.h"
+#include "exception.h"
 #include <vector>
 #include <array>
 #include <iostream>
@@ -34,7 +35,7 @@ struct Atom{
       case 1: return pos_y;
       case 2: return pos_z;
     }
-    throw std::invalid_argument;
+    throw ExceptIllegalFunctionCall();
   }
 
   void print(){

--- a/include/atom.h
+++ b/include/atom.h
@@ -2,30 +2,15 @@
 
 #define ATOM_H
 
-#include "exception.h"
 #include "vector.h"
 #include <vector>
 #include <array>
 #include <iostream>
 
 struct Atom{ 
-  Atom(){
-    pos_x = 0;
-    pos_y = 0;
-    pos_z = 0;
-    rad = -1;
-    number = -1;
-    symbol = "Empty";
-  }
-
+  Atom() : pos_x(0), pos_y(0), pos_z(0), rad(-1), number(0), symbol("") {}
   Atom(const double& x_inp, const double& y_inp, const double& z_inp, const std::string& symbol_inp, const double& rad_inp, const int& elem_Z_inp)
-    : pos_x(x_inp),
-      pos_y(y_inp),
-      pos_z(z_inp),
-      rad(rad_inp),
-      number(elem_Z_inp),
-      symbol(symbol_inp) {}
-  // TODO destructor
+    : pos_x(x_inp), pos_y(y_inp), pos_z(z_inp), rad(rad_inp), number(elem_Z_inp), symbol(symbol_inp) {}
 
   double pos_x, pos_y, pos_z, rad;
   unsigned int number;
@@ -49,16 +34,14 @@ struct Atom{
       case 1: return pos_y;
       case 2: return pos_z;
     }
-    throw ExceptIllegalFunctionCall();
+    throw std::invalid_argument;
   }
+
   void print(){
-    printf("Object: Atom {%s, (%1.3f, %1.3f, %1.3f)}", symbol.c_str(), pos_x, pos_y, pos_z);
-    return;
+    printf("Atom {%s, (%1.3f, %1.3f, %1.3f)}", symbol.c_str(), pos_x, pos_y, pos_z);
   }
 
-  bool isValid() const {return (rad != -1);}
-
+  bool isValid() const {return (rad >= 0);}
 };
-
 
 #endif

--- a/include/atomtree.h
+++ b/include/atomtree.h
@@ -32,7 +32,7 @@ class AtomNode;
 class AtomTree{
   public:
     AtomTree();
-    AtomTree(std::vector<Atom>& list_of_atoms);
+    AtomTree(const std::vector<Atom>& list_of_atoms);
     ~AtomTree();
     
     const AtomNode* getRoot() const;

--- a/include/atomtree.h
+++ b/include/atomtree.h
@@ -14,17 +14,17 @@ class AtomNode{
     AtomNode* getLeftChild() const;
     AtomNode* getRightChild() const;
     Atom& getAtom() const;
-    static Atom& getAtom(const int);
     int getAtomId() const;
     void print();
 
+    static Atom& getAtom(const int);
     static void setAtomList(const std::vector<Atom>&);
     static std::vector<Atom>& getAtomList();
   private:
     AtomNode* _left_child;
     AtomNode* _right_child;
     int _atom_id;
-    static inline std::vector<Atom> _atom_list;
+    static inline std::vector<Atom> s_atom_list;
 };
 
 struct Atom;

--- a/include/atomtree.h
+++ b/include/atomtree.h
@@ -9,6 +9,7 @@ class AtomTree;
 class AtomNode{
   public:
     AtomNode(int, AtomNode* left_node, AtomNode* right_node);
+    ~AtomNode();
  
     AtomNode* getLeftChild() const;
     AtomNode* getRightChild() const;

--- a/include/atomtree.h
+++ b/include/atomtree.h
@@ -33,6 +33,7 @@ class AtomTree{
   public:
     AtomTree();
     AtomTree(std::vector<Atom>& list_of_atoms);
+    ~AtomTree();
     
     const AtomNode* getRoot() const;
     const double getMaxRad() const;

--- a/include/atomtree.h
+++ b/include/atomtree.h
@@ -9,18 +9,19 @@ class AtomTree;
 class AtomNode{
   public:
     AtomNode(int, AtomNode* left_node, AtomNode* right_node);
-  
-    // TODO: move children to private
-    AtomNode* left_child;
-    AtomNode* right_child;
-  
+ 
+    AtomNode* getLeftChild() const;
+    AtomNode* getRightChild() const;
     Atom& getAtom() const;
     static Atom& getAtom(const int);
     int getAtomId() const;
     void print(); // used for testing
+
     static void setAtomList(const std::vector<Atom>&);
     static std::vector<Atom>& getAtomList();
   private:
+    AtomNode* _left_child;
+    AtomNode* _right_child;
     int _atom_id;
     static inline std::vector<Atom> _atom_list;
 };

--- a/include/atomtree.h
+++ b/include/atomtree.h
@@ -16,7 +16,7 @@ class AtomNode{
     Atom& getAtom() const;
     static Atom& getAtom(const int);
     int getAtomId() const;
-    void print(); // used for testing
+    void print();
 
     static void setAtomList(const std::vector<Atom>&);
     static std::vector<Atom>& getAtomList();
@@ -38,8 +38,6 @@ class AtomTree{
     const AtomNode* getRoot() const;
     const double getMaxRad() const;
     void print() const;
-
-    std::vector<Atom*> findAdjacent(const Atom&, const double&); // may not be needed
   private:
     AtomNode* _root;
     double _max_rad;

--- a/include/base.h
+++ b/include/base.h
@@ -31,8 +31,6 @@ class MainApp: public wxApp
   private:
     void silenceGUI(bool);
     bool isSilent();
-    // colours
-    wxColour col_win = wxColour(160,160,160);
 };
 
 wxDECLARE_EVENT(wxEVT_COMMAND_WORKERTHREAD_COMPLETED, wxThreadEvent);
@@ -226,15 +224,15 @@ class MainFrame: public wxFrame, public wxThreadHelper
     std::vector<wxCheckBox*> getAutoExportCheckBoxes(){return {reportCheckbox, surfaceMapCheckbox, cavityMapsCheckbox};}
 
     // colours
-    wxColour col_panel = wxColour(160,160,160);
-    wxColour col_output = wxColour(192,192,192);
-    wxColour col_white = wxColour(255,255,255);
-    wxColour col_grey_cell = wxColour(150,150,150);
-    wxColour col_red_cell = wxColour(255,75,75);
-    wxColour col_cyan_cell = wxColour(120,255,255);
-    wxColour col_dark_blue = wxColour(35,128,190);
-    wxColour col_light_blue = wxColour(226,255,250);
-    wxColour col_cream = wxColour(255,235,169);
+    wxColour _col_panel = wxColour(160,160,160);
+    wxColour _col_output = wxColour(192,192,192);
+    wxColour _col_white = wxColour(255,255,255);
+    wxColour _col_grey_cell = wxColour(150,150,150);
+    wxColour _col_red_cell = wxColour(255,75,75);
+    wxColour _col_cyan_cell = wxColour(120,255,255);
+    wxColour _col_dark_blue = wxColour(35,128,190);
+    wxColour _col_light_blue = wxColour(226,255,250);
+    wxColour _col_cream = wxColour(255,235,169);
 
     DECLARE_EVENT_TABLE()
 };

--- a/include/controller.h
+++ b/include/controller.h
@@ -51,10 +51,10 @@ class Ctrl{
     inline static const std::string s_version = "alpha";
   private:
     // consider making static pointer for model
-    Model* current_calculation;
+    Model* _current_calculation;
     // static attributes to ensure there is only one of each
-    static Ctrl* instance;
-    static MainFrame* gui;
+    static Ctrl* s_instance;
+    static MainFrame* s_gui;
 
     bool _abort_calculation; // variable for main thread to signal stopping the calculation
     bool _calculation_finished;

--- a/include/model.h
+++ b/include/model.h
@@ -124,16 +124,16 @@ class Model{
     CalcReportBundle _data;
     std::string _time_stamp; // stores the time when the calculation was run for output folder and report
     std::string _output_folder = "."; // default folder is the program folder but it is changed with the output file routine
-    std::vector<std::tuple<std::string, double, double, double>> raw_atom_coordinates;
-    std::vector<std::tuple<std::string, double, double, double>> processed_atom_coordinates;
+    std::vector<std::tuple<std::string, double, double, double>> _raw_atom_coordinates;
+    std::vector<std::tuple<std::string, double, double, double>> _processed_atom_coordinates;
     double _cell_param[6]; // unit cell parameters in order: A, B, C, alpha, beta, gamma
     double _cart_matrix[3][3]; // cartesian coordinates of vectors A, B, C
-    std::string space_group;
-    std::unordered_map<std::string, double> radius_map;
-    std::unordered_map<std::string, int> elem_Z;
-    std::map<std::string, int> atom_amounts;
-    std::map<std::string, int> unit_cell_atom_amounts; // stores atoms of unit cell to generate chemical formula
-    std::vector<Atom> atoms;
+    std::string _space_group;
+    std::unordered_map<std::string, double> _radius_map;
+    std::unordered_map<std::string, int> _elem_Z;
+    std::map<std::string, int> _atom_amounts;
+    std::map<std::string, int> _unit_cell_atom_amounts; // stores atoms of unit cell to generate chemical formula
+    std::vector<Atom> _atoms;
     Space _cell;
     double _max_atom_radius = 0;
 

--- a/include/model.h
+++ b/include/model.h
@@ -111,7 +111,6 @@ class Model{
     // calls the Space constructor and creates a cell containing all atoms. Cell size is defined by atom positions
     void defineCell();
     void setAtomListForCalculation();
-    void storeAtomsInTree();
     void linkAtomsToAdjacentAtoms(const double&);
     void linkToAdjacentAtoms(const double&, Atom&);
     CalcReportBundle calcVolume();
@@ -135,7 +134,6 @@ class Model{
     std::map<std::string, int> atom_amounts;
     std::map<std::string, int> unit_cell_atom_amounts; // stores atoms of unit cell to generate chemical formula
     std::vector<Atom> atoms;
-    AtomTree atomtree;
     Space _cell;
     double _max_atom_radius = 0;
 

--- a/include/model.h
+++ b/include/model.h
@@ -124,7 +124,7 @@ class Model{
   private:
     CalcReportBundle _data;
     std::string _time_stamp; // stores the time when the calculation was run for output folder and report
-    std::string output_folder = "."; // default folder is the program folder but it is changed with the output file routine
+    std::string _output_folder = "."; // default folder is the program folder but it is changed with the output file routine
     std::vector<std::tuple<std::string, double, double, double>> raw_atom_coordinates;
     std::vector<std::tuple<std::string, double, double, double>> processed_atom_coordinates;
     double _cell_param[6]; // unit cell parameters in order: A, B, C, alpha, beta, gamma

--- a/include/space.h
+++ b/include/space.h
@@ -46,7 +46,7 @@ class Space{
     void printGrid();
 
     // type evaluation
-    void assignTypeInGrid(const AtomTree&, const double, const double, bool, bool&);
+    void assignTypeInGrid(std::vector<Atom>&, const double, const double, bool, bool&);
     void getVolume(std::map<char,double>&, std::vector<Cavity>&);
     void getUnitCellVolume(std::map<char,double>&, std::vector<Cavity>&);
     void setUnitCellIndexes();

--- a/include/test.h
+++ b/include/test.h
@@ -1,3 +1,0 @@
-
-
-int calcSum(int a, int b);

--- a/include/voxel.h
+++ b/include/voxel.h
@@ -74,7 +74,7 @@ class Voxel{
         const std::array<unsigned,3>&,
         const int);
 
-    // unused but could become usefil
+    // unused but could become useful
     static void listFromTree(std::vector<int>&, const AtomNode*, const Vector&, const double&, const double&, const double&, const char=0);
   private:
     char _type;

--- a/include/voxel.h
+++ b/include/voxel.h
@@ -65,16 +65,6 @@ class Voxel{
     // shell vs void
     char evalRelationToVoxels(const std::array<unsigned int,3>&, const unsigned, bool=false);
 
-    // unused
-    static void listFromTree(
-        std::vector<int>&,
-        const AtomNode*,
-        const Vector&,
-        const double&,
-        const double&,
-        const double&,
-        const char=0);
-
     // volume
     void tallyVoxelsOfType(std::map<char,unsigned>&,
         std::map<unsigned char,unsigned>&,
@@ -84,6 +74,8 @@ class Voxel{
         const std::array<unsigned,3>&,
         const int);
 
+    // unused but could become usefil
+    static void listFromTree(std::vector<int>&, const AtomNode*, const Vector&, const double&, const double&, const double&, const char=0);
   private:
     char _type;
     unsigned char _identity;

--- a/include/voxel.h
+++ b/include/voxel.h
@@ -47,7 +47,7 @@ class Voxel{
     bool isAssigned(); // state of bit 0
 
     // calc preparation
-    static void prepareTypeAssignment(Space*, AtomTree);
+    static void prepareTypeAssignment(Space*, std::vector<Atom>&);
     static void storeProbe(const double, const bool);
     static void computeIndices();
     static void computeIndices(unsigned int);
@@ -82,7 +82,7 @@ class Voxel{
 
     static inline Space* s_cell; // gets destroyed by Model
     // atom vs core
-    static inline AtomTree s_atomtree;
+    static inline AtomTree* s_atomtree;
     // shell vs void
     static inline double s_r_probe;
     static inline bool s_masking_mode;

--- a/include/voxel.h
+++ b/include/voxel.h
@@ -88,7 +88,7 @@ class Voxel{
     char _type;
     unsigned char _identity;
 
-    static inline Space* s_cell;
+    static inline Space* s_cell; // gets destroyed by Model
     // atom vs core
     static inline AtomTree s_atomtree;
     // shell vs void
@@ -96,7 +96,7 @@ class Voxel{
     static inline bool s_masking_mode;
     static inline SearchIndex s_search_indices;
 
-    static inline double calcRadiusOfInfluence(const double& max_depth);
+    static inline double calcVxlRadius(const double& max_depth);
 
     // atom vs core
     bool isAtom(const Atom&, const Vector&, const double, const double);

--- a/src/atomtree.cpp
+++ b/src/atomtree.cpp
@@ -17,10 +17,17 @@ void findAdjacentRecursive(std::vector<Atom*>&, const Atom&, const double& shell
 
 // CONSTRUCTOR
 
-AtomNode::AtomNode(int atom_id, AtomNode* left_node, AtomNode* right_node)
-    : left_child(left_node), right_child(right_node), _atom_id(atom_id) {}
+AtomNode::AtomNode(int atom_id, AtomNode* left_node, AtomNode* right_node) : _left_child(left_node), _right_child(right_node), _atom_id(atom_id) {}
 
 // ACCESS
+
+AtomNode* AtomNode::getLeftChild() const {
+  return _left_child;
+}
+
+AtomNode* AtomNode::getRightChild() const {
+  return _right_child;
+}
 
 void AtomNode::setAtomList(const std::vector<Atom>& atom_list){
   AtomNode::_atom_list = atom_list;
@@ -51,12 +58,12 @@ void AtomNode::print(){
     << getAtom().getCoordinate(2) << ")";
 
   std::cout << "(-";
-  if(left_child!=NULL){
-    left_child->print();
+  if(getLeftChild() != NULL){
+    getLeftChild()->print();
   }
   std::cout << " +";
-  if(right_child!=NULL){
-    right_child->print();
+  if(getRightChild() != NULL){
+    getRightChild()->print();
   }
   std::cout << ")";
   return;
@@ -208,7 +215,7 @@ void findAdjacentRecursive(
         atom,
         shell_to_shell_dist,
         min_distance,
-        dist1D < 0 ? node->left_child : node->right_child,
+        dist1D < 0 ? node->getLeftChild() : node->getRightChild(),
         (dim+1)%3);
   }
   else{ // if atom is close enough to test atom that is could be adjacent
@@ -218,7 +225,7 @@ void findAdjacentRecursive(
         list_of_adjacent.push_back(test_atom);
       }
     }
-    for (AtomNode* child : {node->left_child, node->right_child}){
+    for (AtomNode* child : {node->getLeftChild(), node->getRightChild()}){
       findAdjacentRecursive(list_of_adjacent, atom, shell_to_shell_dist, min_distance, child, (dim+1)%3);
     }
   }

--- a/src/atomtree.cpp
+++ b/src/atomtree.cpp
@@ -57,7 +57,6 @@ int AtomNode::getAtomId() const {
 }
 
 // OTHER
-// for testing
 void AtomNode::print(){
   std::cout << getAtom().symbol << "("
     << getAtom().getCoordinate(0) << ","
@@ -194,52 +193,3 @@ const double AtomTree::getMaxRad() const {
 const AtomNode* AtomTree::getRoot() const {
   return _root;
 }
-
-// NEIGHBOUR LIST
-
-// changes to AtomNode and AtomTree neccessitate a reevaluation of this function
-std::vector<Atom*> AtomTree::findAdjacent(const Atom& at, const double& shell_to_shell_dist){
-  std::vector<Atom*> list_of_adjacent;
-  int dim = 0;
-  double min_distance = at.rad + _max_rad + shell_to_shell_dist;
-
-  findAdjacentRecursive(list_of_adjacent, at, shell_to_shell_dist, min_distance, _root, dim);
-
-  return list_of_adjacent;
-}
-
-// changes to AtomNode and AtomTree neccessitate a reevaluation of this function
-void findAdjacentRecursive(
-    std::vector<Atom*>& list_of_adjacent,
-    const Atom& atom,
-    const double& shell_to_shell_dist,
-    const double& min_distance,
-    const AtomNode* node,
-    int dim){
-
-  if (node == NULL) {return;}
-  Atom* test_atom = &node->getAtom(); // for easier access
-  double dist1D = distance(test_atom->getPos(), atom.getPos(), dim);
-
-  if (abs(dist1D) > min_distance){ // if atom is very far from test atom
-    findAdjacentRecursive(
-        list_of_adjacent,
-        atom,
-        shell_to_shell_dist,
-        min_distance,
-        dist1D < 0 ? node->getLeftChild() : node->getRightChild(),
-        (dim+1)%3);
-  }
-  else{ // if atom is close enough to test atom that is could be adjacent
-    double dist_at_at = distance(atom.getPos(), test_atom->getPos());
-    if (dist_at_at < (atom.rad + test_atom->rad + shell_to_shell_dist)){ // if test atom is adjacent
-      if (&atom != test_atom){ // if its not the same atom
-        list_of_adjacent.push_back(test_atom);
-      }
-    }
-    for (AtomNode* child : {node->getLeftChild(), node->getRightChild()}){
-      findAdjacentRecursive(list_of_adjacent, atom, shell_to_shell_dist, min_distance, child, (dim+1)%3);
-    }
-  }
-}
-

--- a/src/atomtree.cpp
+++ b/src/atomtree.cpp
@@ -37,11 +37,11 @@ AtomNode* AtomNode::getRightChild() const {
 }
 
 void AtomNode::setAtomList(const std::vector<Atom>& atom_list){
-  AtomNode::_atom_list = atom_list;
+  AtomNode::s_atom_list = atom_list;
 }
 
 std::vector<Atom>& AtomNode::getAtomList(){
-  return _atom_list;
+  return s_atom_list;
 }
 
 Atom& AtomNode::getAtom() const {
@@ -49,7 +49,7 @@ Atom& AtomNode::getAtom() const {
 }
 
 Atom& AtomNode::getAtom(const int atom_id){
-  return _atom_list[atom_id];
+  return s_atom_list[atom_id];
 }
 
 int AtomNode::getAtomId() const {

--- a/src/atomtree.cpp
+++ b/src/atomtree.cpp
@@ -97,6 +97,12 @@ AtomTree::AtomTree(std::vector<Atom>& list_of_atoms){
   _max_rad = findMaxRad(list_of_atoms);
 }
 
+// DESTRUCTOR
+
+AtomTree::~AtomTree(){
+  delete _root;
+}
+
 // FUNCTIONS USED BY CONSTRUCTOR
 
 // recursive function to generate a 3-d tree from a list of atoms
@@ -120,7 +126,6 @@ AtomNode* AtomTree::buildTree(
     quicksort(AtomNode::getAtomList(), vec_first, vec_end, dim);
     int median = vec_first + (vec_end-vec_first)/2; // operation rounds down
     return new AtomNode(
-//        AtomNode::getAtomList()[median],
         median,
         buildTree(vec_first, median, (dim+1)%3),
         buildTree(median+1, vec_end, (dim+1)%3));

--- a/src/atomtree.cpp
+++ b/src/atomtree.cpp
@@ -86,14 +86,14 @@ AtomTree::AtomTree(){
   _max_rad = 0;
 }
 
-AtomTree::AtomTree(std::vector<Atom>& list_of_atoms){
+AtomTree::AtomTree(const std::vector<Atom>& list_of_atoms){
   AtomNode::setAtomList(list_of_atoms);
-  _root = buildTree(0, list_of_atoms.size(), 0);
+  _root = buildTree(0, AtomNode::getAtomList().size(), 0);
   // ideally, the maximum radius would be the largest radius among all children of a node.
   // this, however, may require running an algorithm for every tree node, increasing the
   // complexity of the operation. it is much simpler to use the maximum radius among all
   // atoms instead, sacrificing optimisation.
-  _max_rad = findMaxRad(list_of_atoms);
+  _max_rad = findMaxRad(AtomNode::getAtomList());
 }
 
 // DESTRUCTOR
@@ -124,10 +124,7 @@ AtomNode* AtomTree::buildTree(
   else{
     quicksort(AtomNode::getAtomList(), vec_first, vec_end, dim);
     int median = vec_first + (vec_end-vec_first)/2; // operation rounds down
-    return new AtomNode(
-        median,
-        buildTree(vec_first, median, (dim+1)%3),
-        buildTree(median+1, vec_end, (dim+1)%3));
+    return new AtomNode(median, buildTree(vec_first, median, (dim+1)%3), buildTree(median+1, vec_end, (dim+1)%3));
   }
 }
 

--- a/src/atomtree.cpp
+++ b/src/atomtree.cpp
@@ -19,6 +19,13 @@ void findAdjacentRecursive(std::vector<Atom*>&, const Atom&, const double& shell
 
 AtomNode::AtomNode(int atom_id, AtomNode* left_node, AtomNode* right_node) : _left_child(left_node), _right_child(right_node), _atom_id(atom_id) {}
 
+// DESTRUCTOR
+
+AtomNode::~AtomNode(){
+  delete _left_child;
+  delete _right_child;
+}
+
 // ACCESS
 
 AtomNode* AtomNode::getLeftChild() const {

--- a/src/base_event.cpp
+++ b/src/base_event.cpp
@@ -190,20 +190,20 @@ void MainFrame::GridChange(wxGridEvent& event){
   wxString value = event.GetString();
   if (col == 0){
     if (value == "1"){
-      atomListGrid->SetCellBackgroundColour(row,1,col_white);
-      atomListGrid->SetCellBackgroundColour(row,2,col_white);
+      atomListGrid->SetCellBackgroundColour(row,1,_col_white);
+      atomListGrid->SetCellBackgroundColour(row,2,_col_white);
     }
     else {
-      atomListGrid->SetCellBackgroundColour(row,1,col_grey_cell);
-      atomListGrid->SetCellBackgroundColour(row,2,col_grey_cell);
+      atomListGrid->SetCellBackgroundColour(row,1,_col_grey_cell);
+      atomListGrid->SetCellBackgroundColour(row,2,_col_grey_cell);
     }
   }
   else if (col == 3){
     if (wcstod(value,NULL) == 0){
-      atomListGrid->SetCellBackgroundColour(row,3,col_red_cell);
+      atomListGrid->SetCellBackgroundColour(row,3,_col_red_cell);
     }
     else {
-      atomListGrid->SetCellBackgroundColour(row,3,col_cyan_cell);
+      atomListGrid->SetCellBackgroundColour(row,3,_col_cyan_cell);
     }
   }
   atomListGrid->ForceRefresh();

--- a/src/base_event.cpp
+++ b/src/base_event.cpp
@@ -190,8 +190,8 @@ void MainFrame::GridChange(wxGridEvent& event){
   wxString value = event.GetString();
   if (col == 0){
     if (value == "1"){
-      atomListGrid->SetCellBackgroundColour(row,1,_col_white);
-      atomListGrid->SetCellBackgroundColour(row,2,_col_white);
+      atomListGrid->SetCellBackgroundColour(row,1,wxNullColour);
+      atomListGrid->SetCellBackgroundColour(row,2,wxNullColour);
     }
     else {
       atomListGrid->SetCellBackgroundColour(row,1,_col_grey_cell);

--- a/src/base_guicontrol.cpp
+++ b/src/base_guicontrol.cpp
@@ -148,9 +148,9 @@ void MainFrame::displayAtomList(std::vector<std::tuple<std::string, int, double>
     // column 0 (include checkbox)
     // if no radius is found for the element, color cells to point it to the user
     if (std::wcstod(atomListGrid->GetCellValue(row, 3), NULL) == 0){
-      atomListGrid->SetCellBackgroundColour(row, 1, col_grey_cell);
-      atomListGrid->SetCellBackgroundColour(row, 2, col_grey_cell);
-      atomListGrid->SetCellBackgroundColour(row, 3, col_red_cell);
+      atomListGrid->SetCellBackgroundColour(row, 1, _col_grey_cell);
+      atomListGrid->SetCellBackgroundColour(row, 2, _col_grey_cell);
+      atomListGrid->SetCellBackgroundColour(row, 3, _col_red_cell);
     }
     else { // if a radius is found, include by default the element
       atomListGrid->SetCellValue(row, 0, "1");

--- a/src/controller_unittest.cpp
+++ b/src/controller_unittest.cpp
@@ -6,7 +6,7 @@
 #include <map>
 
 bool Ctrl::unittestExcluded(){
-  if(current_calculation == NULL){current_calculation = new Model();}
+  if(_current_calculation == NULL){_current_calculation = new Model();}
 
   // parameters for unittest:
   const std::string atom_filepaths[] =
@@ -18,16 +18,16 @@ bool Ctrl::unittestExcluded(){
   const double expected_volumes[] = {1.399000, 4.393000, 9.054000};
 
   // preparation for calling runCalculation()
-  std::unordered_map<std::string, double> rad_map = current_calculation->importRadiusMap(radius_filepath);
-  current_calculation->setRadiusMap(rad_map);
+  std::unordered_map<std::string, double> rad_map = _current_calculation->importRadiusMap(radius_filepath);
+  _current_calculation->setRadiusMap(rad_map);
 
   double error[3];
   CalcReportBundle data[3];
   for (int i = 0; i < 3; i++){
-    current_calculation->readAtomsFromFile(atom_filepaths[i], false);
-    std::vector<std::string> included_elements = current_calculation->listElementsInStructure();
+    _current_calculation->readAtomsFromFile(atom_filepaths[i], false);
+    std::vector<std::string> included_elements = _current_calculation->listElementsInStructure();
 
-    current_calculation->setParameters(
+    _current_calculation->setParameters(
         atom_filepaths[i],
         "./output",
         false,
@@ -45,7 +45,7 @@ bool Ctrl::unittestExcluded(){
         included_elements,
         3);
 
-    data[i] = current_calculation->generateData();
+    data[i] = _current_calculation->generateData();
     if(data[i].success){
       error[i] = abs(data[i].volumes[0b00000101]-expected_volumes[i])/data[i].volumes[0b00000101];
     }
@@ -64,7 +64,7 @@ bool Ctrl::unittestExcluded(){
 }
 
 bool Ctrl::unittestProtein(){
-  if(current_calculation == NULL){current_calculation = new Model();}
+  if(_current_calculation == NULL){_current_calculation = new Model();}
 
   // parameters for unittest:
   const std::string atom_filepath = "./inputfile/6s8y.xyz";
@@ -75,15 +75,15 @@ bool Ctrl::unittestProtein(){
   const double expected_vdwVolume = 14337.422000;
   const double expected_time = 67;
 
-  std::unordered_map<std::string, double> rad_map = current_calculation->importRadiusMap(radius_filepath);
+  std::unordered_map<std::string, double> rad_map = _current_calculation->importRadiusMap(radius_filepath);
 
   double error_vdwVolume;
   double diff_time;
   CalcReportBundle data;
-  current_calculation->readAtomsFromFile(atom_filepath, false);
-  std::vector<std::string> included_elements = current_calculation->listElementsInStructure();
+  _current_calculation->readAtomsFromFile(atom_filepath, false);
+  std::vector<std::string> included_elements = _current_calculation->listElementsInStructure();
 
-  current_calculation->setParameters(
+  _current_calculation->setParameters(
       atom_filepath,
       "./output",
       false,
@@ -101,7 +101,7 @@ bool Ctrl::unittestProtein(){
       included_elements,
       3);
 
-  data = current_calculation->generateData();
+  data = _current_calculation->generateData();
   if(data.success){
     error_vdwVolume = abs(data.volumes[0b00000011]-expected_vdwVolume)/data.volumes[0b00000011];
     diff_time = data.getTime() - expected_time;
@@ -117,7 +117,7 @@ bool Ctrl::unittestProtein(){
 }
 
 bool Ctrl::unittestRadius(){
-  if(current_calculation == NULL){current_calculation = new Model();}
+  if(_current_calculation == NULL){_current_calculation = new Model();}
 
   // parameters for unittest:
   const std::string atom_filepath = "./inputfile/probetest_pair.xyz";
@@ -125,7 +125,7 @@ bool Ctrl::unittestRadius(){
   double rad_probe2 = 1.2;
   bool two_probe = true;
 
-  std::unordered_map<std::string, double> rad_map = current_calculation->importRadiusMap(radius_filepath);
+  std::unordered_map<std::string, double> rad_map = _current_calculation->importRadiusMap(radius_filepath);
   {int max_depth = 4;
     //for (int max_depth = 4; max_depth < ; max_depth++){
     {double grid_step = 0.1;
@@ -135,10 +135,10 @@ bool Ctrl::unittestRadius(){
 
 
         CalcReportBundle data;
-        current_calculation->readAtomsFromFile(atom_filepath, false);
-        std::vector<std::string> included_elements = current_calculation->listElementsInStructure();
+        _current_calculation->readAtomsFromFile(atom_filepath, false);
+        std::vector<std::string> included_elements = _current_calculation->listElementsInStructure();
 
-        current_calculation->setParameters(
+        _current_calculation->setParameters(
             atom_filepath,
             "./output",
             false,
@@ -156,7 +156,7 @@ bool Ctrl::unittestRadius(){
             included_elements,
             3);
 
-        data = current_calculation->generateData();
+        data = _current_calculation->generateData();
 
         if(data.success){
           printf("f: %40s, g: %4.2f, d: %4i, r: %4.1f\n", atom_filepath.c_str(), grid_step, max_depth, rad_probe1);
@@ -173,7 +173,7 @@ bool Ctrl::unittestRadius(){
 }
 
 bool Ctrl::unittest2Probe(){
-  if(current_calculation == NULL){current_calculation = new Model();}
+  if(_current_calculation == NULL){_current_calculation = new Model();}
 
   // parameters for unittest:
   const std::string atom_filepath = "./inputfile/probetest_quadruplet.xyz";
@@ -184,13 +184,13 @@ bool Ctrl::unittest2Probe(){
   int max_depth = 4;
   double grid_step = 0.1;
 
-  std::unordered_map<std::string, double> rad_map = current_calculation->importRadiusMap(radius_filepath);
+  std::unordered_map<std::string, double> rad_map = _current_calculation->importRadiusMap(radius_filepath);
 
   CalcReportBundle data;
-  current_calculation->readAtomsFromFile(atom_filepath, false);
-  std::vector<std::string> included_elements = current_calculation->listElementsInStructure();
+  _current_calculation->readAtomsFromFile(atom_filepath, false);
+  std::vector<std::string> included_elements = _current_calculation->listElementsInStructure();
 
-  current_calculation->setParameters(
+  _current_calculation->setParameters(
       atom_filepath,
       "./output",
       false,
@@ -208,7 +208,7 @@ bool Ctrl::unittest2Probe(){
       included_elements,
       3);
 
-  data = current_calculation->generateData();
+  data = _current_calculation->generateData();
 
   if(data.success){
     printf("f: %40s, g: %4.2f, d: %4i, r1: %4.1f, r2: %4.1f\n",
@@ -225,7 +225,7 @@ bool Ctrl::unittest2Probe(){
 }
 
 bool Ctrl::unittestSurface(){
-  if(current_calculation == NULL){current_calculation = new Model();}
+  if(_current_calculation == NULL){_current_calculation = new Model();}
 
   // parameters for unittest:
   const std::string atom_filepath = "./inputfile/6s8y.xyz";
@@ -237,13 +237,13 @@ bool Ctrl::unittestSurface(){
   int max_depth = 4;
   double grid_step = 0.1;
 
-  std::unordered_map<std::string, double> rad_map = current_calculation->importRadiusMap(radius_filepath);
+  std::unordered_map<std::string, double> rad_map = _current_calculation->importRadiusMap(radius_filepath);
 
   CalcReportBundle data;
-  current_calculation->readAtomsFromFile(atom_filepath, false);
-  std::vector<std::string> included_elements = current_calculation->listElementsInStructure();
+  _current_calculation->readAtomsFromFile(atom_filepath, false);
+  std::vector<std::string> included_elements = _current_calculation->listElementsInStructure();
 
-  current_calculation->setParameters(
+  _current_calculation->setParameters(
       atom_filepath,
       "./output",
       false,
@@ -261,7 +261,7 @@ bool Ctrl::unittestSurface(){
       included_elements,
       3);
 
-  data = current_calculation->generateData();
+  data = _current_calculation->generateData();
 
   if(data.success){
     printf("f: %40s, g: %4.2f, d: %4i, r1: %4.1f\n", atom_filepath.c_str(), grid_step, max_depth, rad_probe1);
@@ -283,7 +283,7 @@ bool Ctrl::unittestSurface(){
 }
 
 bool Ctrl::unittestFloodfill(){
-  if(current_calculation == NULL){current_calculation = new Model();}
+  if(_current_calculation == NULL){_current_calculation = new Model();}
 
   // parameters for unittest:
   const std::string atom_filepath = "./inputfile/Pd6L4_open_cage_Fujita.xyz";
@@ -295,13 +295,13 @@ bool Ctrl::unittestFloodfill(){
   int max_depth = 4;
   double grid_step = 0.3;
 
-  std::unordered_map<std::string, double> rad_map = current_calculation->importRadiusMap(radius_filepath);
+  std::unordered_map<std::string, double> rad_map = _current_calculation->importRadiusMap(radius_filepath);
 
   CalcReportBundle data;
-  current_calculation->readAtomsFromFile(atom_filepath, false);
-  std::vector<std::string> included_elements = current_calculation->listElementsInStructure();
+  _current_calculation->readAtomsFromFile(atom_filepath, false);
+  std::vector<std::string> included_elements = _current_calculation->listElementsInStructure();
 
-  current_calculation->setParameters(
+  _current_calculation->setParameters(
       atom_filepath,
       "./output",
       false,
@@ -319,7 +319,7 @@ bool Ctrl::unittestFloodfill(){
       included_elements,
       3);
 
-  data = current_calculation->generateData();
+  data = _current_calculation->generateData();
 
   if(data.success){
     printf("f: %40s, g: %4.2f, d: %4i, r1: %4.1f\n", atom_filepath.c_str(), grid_step, max_depth, rad_probe1);

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -54,12 +54,8 @@ bool Model::setParameters(std::string file_path,
     return false;
   }
   _data.atom_file_path = file_path;
-  if(output_dir.empty()){
-    output_folder = ".";
-  }
-  else{
-    output_folder = output_dir;
-  }
+  // TODO: user should always have to specify the output folder. maybe throw exception if output_dir empty
+  _output_folder = output_dir.empty()? "." : output_dir;
   _data.inc_hetatm = inc_hetatm;
   _data.analyze_unit_cell = analyze_unit_cell;
   _data.calc_surface_areas = calc_surface_areas;

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -122,8 +122,6 @@ CalcReportBundle Model::generateVolumeData(){
 
   // determine which atoms will be taken into account
   setAtomListForCalculation();
-  // place atoms in a binary tree for faster access
-  storeAtomsInTree();
   // set size of the box containing all atoms
   defineCell();
 
@@ -273,10 +271,6 @@ void Model::defineCell(){
   return;
 }
 
-void Model::storeAtomsInTree(){
-  atomtree = AtomTree(atoms);
-}
-
 CalcReportBundle Model::calcVolume(){
   // set back the default value of success to true to avoid lingering errors from previous failed calculations
   _data.success = true;
@@ -284,7 +278,7 @@ CalcReportBundle Model::calcVolume(){
   { // assign each voxel in grid a type
     auto start = std::chrono::steady_clock::now();
     bool cavities_exceeded = false;
-    _cell.assignTypeInGrid(atomtree, getProbeRad1(), getProbeRad2(), optionProbeMode(), cavities_exceeded);
+    _cell.assignTypeInGrid(atoms, getProbeRad1(), getProbeRad2(), optionProbeMode(), cavities_exceeded);
     if(Ctrl::getInstance()->getAbortFlag()){
       _data.success = false;
       return _data;

--- a/src/model_filereading.cpp
+++ b/src/model_filereading.cpp
@@ -40,7 +40,7 @@ bool Model::readRadiusFileSetMaps(std::string& radius_path){
   if (data.rad_map.size() == 0) {return false;}
 
   setRadiusMap(data.rad_map);
-  elem_Z = data.atomic_num_map;
+  _elem_Z = data.atomic_num_map;
   return true;
 }
 
@@ -66,16 +66,16 @@ bool Model::readAtomsFromFile(const std::string& filepath, bool include_hetatm){
     throw;
   }
 
-  if (raw_atom_coordinates.size() == 0){ // If no atom is detected in the input file, the file is deemed invalid
+  if (_raw_atom_coordinates.size() == 0){ // If no atom is detected in the input file, the file is deemed invalid
     throw ExceptInvalidInputFile();
   }
   return true;
 }
 
 void Model::clearAtomData(){
-  atom_amounts.clear();
-  raw_atom_coordinates.clear();
-  space_group = "";
+  _atom_amounts.clear();
+  _raw_atom_coordinates.clear();
+  _space_group = "";
   for(int i = 0; i < 6; i++){
     _cell_param[i] = 0;
   }
@@ -109,10 +109,10 @@ void Model::readFileXYZ(const std::string& filepath){
       first_atom_line_encountered = true;
 
       const std::string valid_symbol = strToValidSymbol(substrings[0]);
-      atom_amounts[valid_symbol]++; // adds one to counter for this symbol
+      _atom_amounts[valid_symbol]++; // adds one to counter for this symbol
 
       // Stores the full list of atom coordinates from the input file
-      raw_atom_coordinates.push_back(std::make_tuple(valid_symbol, std::stod(substrings[1]), std::stod(substrings[2]), std::stod(substrings[3])));
+      _raw_atom_coordinates.push_back(std::make_tuple(valid_symbol, std::stod(substrings[1]), std::stod(substrings[2]), std::stod(substrings[3])));
     }
     else {
       // due to the .xyz format the first few lines may not be atom entries. an error should only be detected,
@@ -185,10 +185,10 @@ void Model::readFilePDB(const std::string& filepath, bool include_hetatm){
         invalid_symbol_detected = true;
         continue;
       }
-      atom_amounts[symbol]++; // adds one to counter for this symbol
+      _atom_amounts[symbol]++; // adds one to counter for this symbol
 
       // stores the full list of atom coordinates from the input file
-      raw_atom_coordinates.emplace_back(symbol, atom_line.ortho_coord[0], atom_line.ortho_coord[1], atom_line.ortho_coord[2]);
+      _raw_atom_coordinates.emplace_back(symbol, atom_line.ortho_coord[0], atom_line.ortho_coord[1], atom_line.ortho_coord[2]);
     }
     else if (record_name == "CRYST1"){
       // for the last substring (space group) mercury recognizes only 10 chars but official PDB format is 11 chars
@@ -198,8 +198,8 @@ void Model::readFilePDB(const std::string& filepath, bool include_hetatm){
         try{_cell_param[i] = std::stod(substrings[i]);}
         catch (const std::invalid_argument& e){invalid_cell_params = true;}
       }
-      space_group = substrings[6];
-      removeWhiteSpaces(space_group);
+      _space_group = substrings[6];
+      removeWhiteSpaces(_space_group);
     }
   }
   // file has been read
@@ -212,7 +212,7 @@ void Model::readFilePDB(const std::string& filepath, bool include_hetatm){
 // used in unittest
 std::vector<std::string> Model::listElementsInStructure(){
   std::vector<std::string> list;
-  for (auto elem : atom_amounts){
+  for (auto elem : _atom_amounts){
     list.push_back(elem.first);
   }
   return list;
@@ -267,7 +267,7 @@ bool Model::getSymmetryElements(std::string group, std::vector<int> &sym_matrix_
 
 // returns the radius of an atom with a given symbol
 inline double Model::findRadiusOfAtom(const std::string& symbol){
-  return radius_map[symbol];
+  return _radius_map[symbol];
 }
 
 inline double Model::findRadiusOfAtom(const Atom& at){

--- a/src/model_filereading.cpp
+++ b/src/model_filereading.cpp
@@ -2,6 +2,7 @@
 #include "atom.h"
 #include "controller.h"
 #include "misc.h"
+#include "exception.h"
 #include <string>
 #include <vector>
 #include <iostream>

--- a/src/model_outputfiles.cpp
+++ b/src/model_outputfiles.cpp
@@ -61,7 +61,7 @@ void Model::createReport(std::string path){
   output_report << "Grid step size (resolution): " << _data.grid_step << " A\n";
   output_report << "Maximum tree depth (algorithm acceleration): " << _data.max_depth << "\n";
   output_report << "Elements radii:\n";
-  for(std::unordered_map<std::string, double>::iterator it = radius_map.begin(); it != radius_map.end(); it++){
+  for(std::unordered_map<std::string, double>::iterator it = _radius_map.begin(); it != _radius_map.end(); it++){
     if(isIncluded(it->first, _data.included_elements)){
       output_report << it->first << " : " << it->second << " A\n";
     }
@@ -160,7 +160,7 @@ void Model::createReport(std::string path){
   output_report << "\nIf you wish to visualize the structure file in PyMOL with the same element radii as in the MoloVol calculation,\n";
   output_report << "paste the following command lines (all at once) in the command prompt of PyMOL after opening the structure file.\n\n";
 
-  for(std::unordered_map<std::string, double>::iterator it = radius_map.begin(); it != radius_map.end(); it++){
+  for(std::unordered_map<std::string, double>::iterator it = _radius_map.begin(); it != _radius_map.end(); it++){
     if(isIncluded(it->first, _data.included_elements)){
       output_report << "alter (elem " << it->first << "),vdw=" << it->second << "\n";
     }

--- a/src/model_outputfiles.cpp
+++ b/src/model_outputfiles.cpp
@@ -14,7 +14,7 @@
 ///////////////////
 
 void Model::createReport(){
-  createReport(output_folder+"/MoloVol report " + _time_stamp +".txt");
+  createReport(_output_folder+"/MoloVol report " + _time_stamp +".txt");
 }
 
 void Model::createReport(std::string path){
@@ -182,9 +182,9 @@ void Model::writeCrystStruct(std::string path){
 }
 
 void Model::writeCrystStruct(){
-  std::string path = output_folder+"/struct_orthogonal_cell_"+ _time_stamp +".xyz";
+  std::string path = _output_folder+"/struct_orthogonal_cell_"+ _time_stamp +".xyz";
   writeXYZfile(_data.orth_cell, path, "Orthogonal cell");
-  path = output_folder+"/struct_partial_supercell_"+ _time_stamp +".xyz";
+  path = _output_folder+"/struct_partial_supercell_"+ _time_stamp +".xyz";
   writeXYZfile(_data.supercell, path, "Partial supercell");
 }
 
@@ -205,7 +205,7 @@ void Model::writeXYZfile(const std::vector<std::tuple<std::string, double, doubl
 ////////////////////////
 
 void Model::writeTotalSurfaceMap(){
-  writeTotalSurfaceMap(output_folder + "/full_surface_map_" + _time_stamp + ".dx");
+  writeTotalSurfaceMap(_output_folder + "/full_surface_map_" + _time_stamp + ".dx");
 }
 
 void Model::writeTotalSurfaceMap(const std::string file_path){
@@ -248,7 +248,7 @@ void Model::writeTotalSurfaceMap(const std::string file_path){
 }
 
 void Model::writeCavitiesMaps(){
-  writeCavitiesMaps(output_folder + "/surface_map_" + _time_stamp + ".dx");
+  writeCavitiesMaps(_output_folder + "/surface_map_" + _time_stamp + ".dx");
 }
 
 void Model::writeCavitiesMaps(const std::string file_path){

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -104,9 +104,9 @@ void Space::initGrid(){
 /////////////////////
 
 // sets all voxel's types, determined by the input atoms
-void Space::assignTypeInGrid(const AtomTree& atomtree, const double r_probe1, const double r_probe2, bool probe_mode, bool& cavities_exceeded){
+void Space::assignTypeInGrid(std::vector<Atom>& atomlist, const double r_probe1, const double r_probe2, bool probe_mode, bool& cavities_exceeded){
   // save variable that all voxels need access to for their type determination as static members of Voxel class
-  Voxel::prepareTypeAssignment(this, atomtree);
+  Voxel::prepareTypeAssignment(this, atomlist);
   if (probe_mode){
     // first run algorithm with the larger probe to exclude most voxels - "masking mode"
     Voxel::storeProbe(r_probe2, true);

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -1,6 +1,0 @@
-
-#include "test.h"
-
-int calcSum(int a, int b){
-  return a+b;
-}

--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -299,14 +299,14 @@ void Voxel::traverseTree
   double dist1D = distance(atom.getPosVec(), pos_vxl, dim);
 
   if (abs(dist1D) > (rad_vxl + rad_max + rad_probe)){ // then atom is too far to matter for voxel type
-      traverseTree(dist1D < 0 ? node->left_child : node->right_child,
+      traverseTree(dist1D < 0 ? node->getLeftChild() : node->getRightChild(),
           rad_max, pos_vxl, rad_vxl, rad_probe, max_depth, exit_type, (dim+1)%3);
   }
   else{ // then atom is close enough to influence voxel type
     if(isAtom(atom, pos_vxl, rad_vxl, rad_probe)){return;}
 
     // continue with both children
-    for (AtomNode* child : {node->left_child, node->right_child}){
+    for (AtomNode* child : {node->getLeftChild(), node->getRightChild()}){
       traverseTree(child, rad_max, pos_vxl, rad_vxl, rad_probe, max_depth, exit_type, (dim+1)%3);
     }
   }
@@ -354,7 +354,7 @@ void Voxel::listFromTree(
   double rad_atom = node->getAtom().getRad();
 
   if (abs(dist1D) > rad_point + rad_max + max_dist) { // then atom is too far
-      listFromTree(atom_id_list, dist1D<0? node->left_child : node->right_child, pos_point, rad_point, rad_max, max_dist, (dim+1)%3);
+      listFromTree(atom_id_list, dist1D<0? node->getLeftChild() : node->getRightChild(), pos_point, rad_point, rad_max, max_dist, (dim+1)%3);
   }
   else { // then atom may be close enough
     if ((pos_point-node->getAtom().getPosVec()) < rad_point + rad_atom + max_dist){
@@ -362,7 +362,7 @@ void Voxel::listFromTree(
     }
 
     // continue with both children
-    for (AtomNode* child : {node->left_child, node->right_child}){
+    for (AtomNode* child : {node->getLeftChild(), node->getRightChild()}){
       listFromTree(atom_id_list, child, pos_point, rad_point, rad_max, max_dist, (dim+1)%3);
     }
   }

--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -335,7 +335,6 @@ bool Voxel::isAtom(const Atom& atom, const Vector& pos_vxl, const double rad_vxl
   return false;
 }
 
-// not currently in use
 // go through a tree, starting from node. return a list of atoms that are a specified max distance
 // from a point with radius rad_point.
 void Voxel::listFromTree(

--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -185,9 +185,9 @@ unsigned char Voxel::getID() const {return _identity;}
 /////////////////////////////////
 
 // function to call before beginning the type assignment routine in order to prepare static variables
-void Voxel::prepareTypeAssignment(Space* cell, AtomTree atomtree){
+void Voxel::prepareTypeAssignment(Space* cell, std::vector<Atom>& atoms){
   s_cell = cell;
-  s_atomtree = atomtree;
+  s_atomtree = new AtomTree(atoms);
 }
 
 void Voxel::storeProbe(const double r_probe, const bool masking_mode){
@@ -205,7 +205,7 @@ char Voxel::evalRelationToAtoms(const std::array<unsigned,3>& index_vxl, Vector 
   if (isAssigned()) {return _type;}
   if (!hasSubvoxel()) {
     double rad_vxl = calcVxlRadius(lvl); // calculated every time, since max_depth may change (not expensive)
-    traverseTree(s_atomtree.getRoot(), s_atomtree.getMaxRad(), pos_vxl, rad_vxl, s_r_probe, lvl);
+    traverseTree(s_atomtree->getRoot(), s_atomtree->getMaxRad(), pos_vxl, rad_vxl, s_r_probe, lvl);
     if (_type == 0){_type = s_masking_mode? 0b00100001 : 0b00001001;}
   }
   if (hasSubvoxel()) {

--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -187,6 +187,7 @@ unsigned char Voxel::getID() const {return _identity;}
 // function to call before beginning the type assignment routine in order to prepare static variables
 void Voxel::prepareTypeAssignment(Space* cell, std::vector<Atom>& atoms){
   s_cell = cell;
+  delete s_atomtree;
   s_atomtree = new AtomTree(atoms);
 }
 

--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -12,7 +12,7 @@
 // AUX FUNCTIONS //
 ///////////////////
 
-inline double Voxel::calcRadiusOfInfluence(const double& max_depth){
+inline double Voxel::calcVxlRadius(const double& max_depth){
   return max_depth != 0 ? 0.86602540378 * s_cell->getVxlSize() * (pow(2,max_depth) - 1) : 0;
 }
 char mergeTypes(std::vector<Voxel*>&);
@@ -204,7 +204,7 @@ char Voxel::evalRelationToAtoms(const std::array<unsigned,3>& index_vxl, Vector 
   if(Ctrl::getInstance()->getAbortFlag()){return 0;}
   if (isAssigned()) {return _type;}
   if (!hasSubvoxel()) {
-    double rad_vxl = calcRadiusOfInfluence(lvl); // calculated every time, since max_depth may change (not expensive)
+    double rad_vxl = calcVxlRadius(lvl); // calculated every time, since max_depth may change (not expensive)
     traverseTree(s_atomtree.getRoot(), s_atomtree.getMaxRad(), pos_vxl, rad_vxl, s_r_probe, lvl);
     if (_type == 0){_type = s_masking_mode? 0b00100001 : 0b00001001;}
   }


### PR DESCRIPTION
This branch mostly fixes previous memory leak issues. The memory leaks that were identified, came from the AtomNode and AtomTree classes, because they were missing suitable destructors. Destructors were added and the code was slightly restructured to avoid early calls to the destructor. Test have shown no more memory leaks.

Apart from this private and static members in many classes were renamed to be in line with style guidelines. Smaller changes have also been added, most importantly the behaviour of the atom list grid in the GUI has been changed: when the tick box for including an element is reticked, after being ticked previously, the cell colour no longer changes to white but to the wxWidgets default. This change is necessary for correct display under macOS dark mode.

Resolves: #53 