### PR TITLE
Universal binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,8 @@ cleantest:
 # EXPLICIT CLEAN
 clean:
 	@echo "Cleaning..."; 
-	@echo " $(RM) -r $(BUILDDIR) $(TARGET)"; $(RM) -r $(BUILDDIR) $(TARGET)
+	@echo " $(RM) -r $(BUILDDIR)"; $(RM) -r $(BUILDDIR)
+	@echo " $(RM) -r $(TARGET)"; $(RM) -r $(TARGET)
 	@echo " $(RM) -r $(BINDIR)/arm64_app"; $(RM) -r $(BINDIR)/arm64_app
 	@echo " $(RM) -r $(BINDIR)/x86_app"; $(RM) -r $(BINDIR)/x86_app
 	@echo " $(RM) -r $(BUNDLE)"; $(RM) -r $(BUNDLE)

--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,17 @@ SRCDIR := src
 BUILDDIR := build
 BINDIR := bin
 LINUXRES := res/linux
+SRCEXT := cpp
 APP := MoloVol
 INSTALLERNAME := MoloVol_macOS_beta_v1
-TARGET := $(BINDIR)/$(APP)
 
+TARGET := $(BINDIR)/$(APP)
 BUNDLE := $(TARGET).app
 
 TESTDIR := test
 TESTTARGET := test/out
 TESTBUILDDIR := test/build
 
-SRCEXT := cpp
 SOURCES := $(shell find $(SRCDIR) -type f -name *.$(SRCEXT))
 OBJECTS := $(patsubst $(SRCDIR)/%,$(BUILDDIR)/%,$(SOURCES:.$(SRCEXT)=.o))
 
@@ -25,11 +25,10 @@ RELEASEFLAGS := -O3
 CXXFLAGS := -std=c++17 -Wall -Werror 
 CFLAGS := -std=c++17 -Wno-unused-command-line-argument -Wno-invalid-source-encoding
 WXFLAGS := --cxxflags --libs --version=3.1
-INC := -I include
-
 ARCHFLAG := 
 X86FLAG := -target x86_64-apple-macos10.12
 ARM64FLAG := -target arm64-apple-macos11
+INC := -I include
 
 # DEVELOPMENT BUILD
 all: CXXFLAGS += $(DEBUGFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUILDDIR := build
 BINDIR := bin
 LINUXRES := res/linux
 APP := MoloVol
-DMGNAME :=MoloVol_macOS_beta_v1
+INSTALLERNAME := MoloVol_macOS_beta_v1
 TARGET := $(BINDIR)/$(APP)
 
 BUNDLE := $(TARGET).app
@@ -80,7 +80,7 @@ appbundle: release
 	/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f $(BUNDLE)
 
 dmg: appbundle
-	@echo " $(RM) -r $(BINDIR)/$(DMGNAME).dmg"; $(RM) -r $(BINDIR)/$(DMGNAME).dmg
+	@echo " $(RM) -r $(BINDIR)/$(INSTALLERNAME).dmg"; $(RM) -r $(BINDIR)/$(INSTALLERNAME).dmg
 	@$(RM) -r $(BINDIR)/dmgdir
 	@echo "Creating dmg file..."
 	@mkdir -p $(BINDIR)/dmgdir
@@ -88,7 +88,7 @@ dmg: appbundle
 	@cp README.md $(BINDIR)/dmgdir/README.txt
 	@cp LICENSE $(BINDIR)/dmgdir/LICENSE.txt
 	@ln -s /Applications/ $(BINDIR)/dmgdir/drag_app_here
-	@hdiutil create -fs HFS+ -srcfolder "$(BINDIR)/dmgdir" -volname "$(DMGNAME)" "$(BINDIR)/$(DMGNAME).dmg"
+	@hdiutil create -fs HFS+ -srcfolder "$(BINDIR)/dmgdir" -volname "$(INSTALLERNAME)" "$(BINDIR)/$(INSTALLERNAME).dmg"
 	@$(RM) -r $(BINDIR)/dmgdir
 
 # INSTALLER ON DEBIAN AND UBUNTU
@@ -112,7 +112,7 @@ deb: release
 	@bash $(LINUXRES)/shell/icons.sh $(LINUXRES)/molovol.png $(BINDIR)/deb-staging/usr/share/icons/hicolor
 	@find $(BINDIR)/deb-staging/usr -type f -exec chmod 0644 {} +
 	@chmod 0755 $(BINDIR)/deb-staging/usr/bin/molovol
-	@dpkg-deb --root-owner-group --build "$(BINDIR)/deb-staging" "$(BINDIR)/molovol.deb"
+	@dpkg-deb --root-owner-group --build "$(BINDIR)/deb-staging" "$(BINDIR)/$(INSTALLERNAME).deb"
 	@$(RM) -r $(BINDIR)/deb-staging
 
 # COMPILES ONLY FILES INSIDE TEST DIRECTORY
@@ -136,13 +136,13 @@ clean:
 	@echo " $(RM) -r $(BINDIR)/arm64_app"; $(RM) -r $(BINDIR)/arm64_app
 	@echo " $(RM) -r $(BINDIR)/x86_app"; $(RM) -r $(BINDIR)/x86_app
 	@echo " $(RM) -r $(BUNDLE)"; $(RM) -r $(BUNDLE)
-	@echo " $(RM) -r $(BINDIR)/$(DMGNAME).dmg"; $(RM) -r $(BINDIR)/$(DMGNAME).dmg
-	@echo " $(RM) -r $(BINDIR)/molovol.deb"; $(RM) -r $(BINDIR)/molovol.deb
+	@echo " $(RM) -r $(BINDIR)/$(INSTALLERNAME).dmg"; $(RM) -r $(BINDIR)/$(INSTALLERNAME).dmg
+	@echo " $(RM) -r $(BINDIR)/$(INSTALLERNAME).deb"; $(RM) -r $(BINDIR)/$(INSTALLERNAME).deb
 
 # DELETE BIN DIRECTORY
 cleanall:
 	@echo "Cleaning..."
-	@echo " $(RM) -r $(BINDIR)"; $(RM) -r $(BINDIR)
+	@echo " $(RM) -r $(BUILDIR) $(BINDIR)"; $(RM) -r $(BUILDIR) $(BINDIR)
 
 
 .PHONY: all, clean, cleanall, release, universal_app, x86_app, arm64_app, appbundle, dmg, deb, test, cleantest, probetest, protein


### PR DESCRIPTION
Adds a target to the Makefile for creating a dmg file that includes a universal binary. This universal binary should work on arm64 (Apple Silicon) and x86 (Intel) CPU architectures.