### PR TITLE
Add drop down control for probe 1 input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog keeps track of changes in a user-friendly way. It is based on [ke
 * Fully functional command line interface that allows accessing all functionalities directly form the command line.
 * Macroscopic volume and surface area values are now provided in the report.
 * Unit cell volume fractions are now provided in the report.
+* Add drop down menu with common values to probe radius input text box.
 
 ## [v0.1.0](https://github.com/jmaglic/MoloVol/releases/tag/v0.1.0) - 2021-06-17
 * First beta release

--- a/include/base.h
+++ b/include/base.h
@@ -121,7 +121,7 @@ class MainFrame: public wxFrame, public wxThreadHelper
           wxCheckBox* twoProbesCheckbox;
           wxPanel* probe1Panel;
             wxStaticText* probe1Text;
-            wxTextCtrl* probe1InputText;
+            wxComboBox* probe1DropDown;
             wxStaticText* probe1UnitText; // possibly usable universally?
           wxPanel* probe2Panel;
             wxStaticText* probe2Text;

--- a/src/base_event.cpp
+++ b/src/base_event.cpp
@@ -209,13 +209,24 @@ void MainFrame::GridChange(wxGridEvent& event){
   atomListGrid->ForceRefresh();
 }
 
+static bool s_first_call = true;
 void MainFrame::OnTextInput(wxCommandEvent& event){
-  filepathText->ChangeValue(filepathText->GetValue());
-  elementspathText->ChangeValue(elementspathText->GetValue());
+  if (s_first_call){
+    s_first_call = !s_first_call;
+    return;
+  }
 
-  probe1InputText->ChangeValue(probe1InputText->GetValue());
-  probe2InputText->ChangeValue(probe2InputText->GetValue());
-  gridsizeInputText->ChangeValue(gridsizeInputText->GetValue());
+  wxTextEntry* text_ctrls[] = {
+    filepathText,
+    elementspathText,
+    probe1DropDown,
+    probe2InputText,
+    gridsizeInputText
+  };
+
+  for (auto& elem : text_ctrls){
+    elem->ChangeValue(elem->GetValue());
+  }
 }
 
 ///////////////

--- a/src/base_guicontrol.cpp
+++ b/src/base_guicontrol.cpp
@@ -100,7 +100,7 @@ double MainFrame::getProbe1Radius(){
   try {
     return std::stod(probe1DropDown->GetValue().ToStdString());
   }
-  catch (const std::invalid_argument){
+  catch (const std::invalid_argument& e){
     throw;
   }
 }
@@ -109,7 +109,7 @@ double MainFrame::getProbe2Radius(){
   try{
     return getProbeMode()? std::stod(probe2InputText->GetValue().ToStdString()) : 0;
   }
-  catch (const std::invalid_argument){
+  catch (const std::invalid_argument& e){
     throw;
   }
 }
@@ -118,7 +118,7 @@ double MainFrame::getGridsize(){
   try{
     return std::stod(gridsizeInputText->GetValue().ToStdString());
   }
-  catch (const std::invalid_argument){
+  catch (const std::invalid_argument& e){
     throw;
   }
 }

--- a/src/base_guicontrol.cpp
+++ b/src/base_guicontrol.cpp
@@ -97,7 +97,7 @@ bool MainFrame::getProbeMode(){
 }
 
 double MainFrame::getProbe1Radius(){
-  return std::stod(probe1InputText->GetValue().ToStdString());
+  return std::stod(probe1DropDown->GetValue().ToStdString());
 }
 
 double MainFrame::getProbe2Radius(){

--- a/src/base_guicontrol.cpp
+++ b/src/base_guicontrol.cpp
@@ -97,15 +97,30 @@ bool MainFrame::getProbeMode(){
 }
 
 double MainFrame::getProbe1Radius(){
-  return std::stod(probe1DropDown->GetValue().ToStdString());
+  try {
+    return std::stod(probe1DropDown->GetValue().ToStdString());
+  }
+  catch (const std::invalid_argument){
+    throw;
+  }
 }
 
 double MainFrame::getProbe2Radius(){
-  return getProbeMode()? std::stod(probe2InputText->GetValue().ToStdString()) : 0;
+  try{
+    return getProbeMode()? std::stod(probe2InputText->GetValue().ToStdString()) : 0;
+  }
+  catch (const std::invalid_argument){
+    throw;
+  }
 }
 
 double MainFrame::getGridsize(){
-  return std::stod(gridsizeInputText->GetValue().ToStdString());
+  try{
+    return std::stod(gridsizeInputText->GetValue().ToStdString());
+  }
+  catch (const std::invalid_argument){
+    throw;
+  }
 }
 
 int MainFrame::getDepth(){

--- a/src/base_init.cpp
+++ b/src/base_init.cpp
@@ -305,11 +305,14 @@ void MainFrame::InitProbe1Panel(){
 
   const wxString drop_down_options[] = {
     "1.2 (Hydrogen)",
-    "1.4 (Water)"
+    "1.4 (Water)",
+    "1.66 (Nitrogen)",
+    "1.83 (Argon)",
+    "1.86 (N2 sphere rad.)"
   };
 
   probe1Text = new wxStaticText(probe1Panel, TEXT_Probe1, "Small Probe radius:");
-  probe1DropDown = new wxComboBox(probe1Panel, TEXT_Probe1Input, "1.2", wxDefaultPosition, wxDefaultSize, 
+  probe1DropDown = new wxComboBox(probe1Panel, TEXT_Probe1Input, "1.2", wxDefaultPosition, wxDefaultSize,
       sizeof(drop_down_options)/sizeof(drop_down_options[0]), drop_down_options);
   probe1UnitText = new wxStaticText(probe1Panel, TEXT_Probe1Unit, L" \u212B"); // unicode for angstrom
 

--- a/src/base_init.cpp
+++ b/src/base_init.cpp
@@ -51,7 +51,7 @@ void MainFrame::InitDefaultStates(){
     atomListGrid,
     surfaceAreaCheckbox,
     twoProbesCheckbox,
-    probe1InputText,
+    probe1DropDown,
     gridsizeInputText,
     depthInput,
     reportCheckbox,
@@ -303,13 +303,19 @@ void MainFrame::InitParametersPanel(){
 
 void MainFrame::InitProbe1Panel(){
 
+  const wxString drop_down_options[] = {
+    "1.2 (Hydrogen)",
+    "1.4 (Water)"
+  };
+
   probe1Text = new wxStaticText(probe1Panel, TEXT_Probe1, "Small Probe radius:");
-  probe1InputText = new wxTextCtrl(probe1Panel, TEXT_Probe1Input, "1.2");
+  probe1DropDown = new wxComboBox(probe1Panel, TEXT_Probe1Input, "1.2", wxDefaultPosition, wxDefaultSize, 
+      sizeof(drop_down_options)/sizeof(drop_down_options[0]), drop_down_options);
   probe1UnitText = new wxStaticText(probe1Panel, TEXT_Probe1Unit, L" \u212B"); // unicode for angstrom
 
   wxBoxSizer *probe1Sizer = new wxBoxSizer(wxHORIZONTAL);
   probe1Sizer->Add(probe1Text,1,wxALIGN_CENTRE_VERTICAL);
-  probe1Sizer->Add(probe1InputText, 1, wxALIGN_CENTRE_VERTICAL);
+  probe1Sizer->Add(probe1DropDown, 1, wxALIGN_CENTRE_VERTICAL);
   probe1Sizer->Add(probe1UnitText, 1, wxALIGN_CENTRE_VERTICAL);
   probe1Panel->SetSizerAndFit(probe1Sizer);
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -150,7 +150,7 @@ bool Ctrl::runCalculation(){
       return false;
     }
   }
-  catch (const std::invalid_argument&){
+  catch (const std::invalid_argument& e){
     displayErrorMessage(109);
     return false;
   }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -130,22 +130,28 @@ bool Ctrl::runCalculation(){
 
   // PARAMETERS
   // save parameters in model
-  if(!_current_calculation->setParameters(
-      s_gui->getAtomFilepath(),
-      s_gui->getOutputDir(),
-      s_gui->getIncludeHetatm(),
-      s_gui->getAnalyzeUnitCell(),
-      s_gui->getCalcSurfaceAreas(),
-      s_gui->getProbeMode(),
-      s_gui->getProbe1Radius(),
-      s_gui->getProbe2Radius(),
-      s_gui->getGridsize(),
-      s_gui->getDepth(),
-      s_gui->getMakeReport(),
-      s_gui->getMakeSurfaceMap(),
-      s_gui->getMakeCavityMaps(),
-      s_gui->generateRadiusMap(),
-      s_gui->getIncludedElements())){
+  try{
+    if(!_current_calculation->setParameters(
+        s_gui->getAtomFilepath(),
+        s_gui->getOutputDir(),
+        s_gui->getIncludeHetatm(),
+        s_gui->getAnalyzeUnitCell(),
+        s_gui->getCalcSurfaceAreas(),
+        s_gui->getProbeMode(),
+        s_gui->getProbe1Radius(),
+        s_gui->getProbe2Radius(),
+        s_gui->getGridsize(),
+        s_gui->getDepth(),
+        s_gui->getMakeReport(),
+        s_gui->getMakeSurfaceMap(),
+        s_gui->getMakeCavityMaps(),
+        s_gui->generateRadiusMap(),
+        s_gui->getIncludedElements())){
+      return false;
+    }
+  }
+  catch (const std::invalid_argument&){
+    displayErrorMessage(109);
     return false;
   }
 
@@ -557,6 +563,7 @@ static const std::map<int, std::string> s_error_codes = {
   {106, "Invalid element symbol(s) in elements file detected. Some radii may be assigned incorrectly. Please make sure that all element symbols begin with an alphabetic character."},
   {107, "Invalid radius value in elements file detected. Some radii may be set to 0. Please make sure that all radii are numeric."},
   {108, "Invalid atomic weight value in elements file detected. Some atomic weights may be set to 0. Please make sure that all atomic weights are numeric."},
+  {109, "Invalid numeric input. Please make sure that all input values have a valid number format."},
   // 11x: unit cell files
   {111, "Space group not found. Check the structure file, or untick the Unit Cell Analysis tickbox."},
   {112, "Invalid unit cell parameters. Check the structure file, or untick the Unit Cell Analysis tickbox."},


### PR DESCRIPTION
As we've already had two testers asking for this feature, I've decided to quickly implement it. You will notice that the parentheses remain after the selection. This is luckily no issue, because `std::stod` just ignores them. I wanted to make them disappear upon selection, but wxComboBox is unfortunately not perfectly reliable when it comes to the item-selection event.

Feel free to add any options you think are necessary.